### PR TITLE
Feature: cache clean up

### DIFF
--- a/Pod/Tests/Specs/Storage/DiskStorageSpec.swift
+++ b/Pod/Tests/Specs/Storage/DiskStorageSpec.swift
@@ -143,6 +143,38 @@ class DiskStorageSpec: QuickSpec {
         }
       }
 
+      describe("clearExpired") {
+        it("removes expired objects") {
+          let expectation1 = self.expectationWithDescription(
+            "Clear If Expired Expectation")
+          let expectation2 = self.expectationWithDescription(
+            "Don't Clear If Not Expired Expectation")
+
+          let expiry1: Expiry = .Date(NSDate().dateByAddingTimeInterval(-100000))
+          let expiry2: Expiry = .Date(NSDate().dateByAddingTimeInterval(100000))
+
+          let key1 = "item1"
+          let key2 = "item2"
+
+          storage.add(key1, object: object, expiry: expiry1)
+          storage.add(key2, object: object, expiry: expiry2)
+
+          storage.clearExpired {
+            storage.object(key1) { (receivedObject: User?) in
+              expect(receivedObject).to(beNil())
+              expectation1.fulfill()
+            }
+
+            storage.object(key2) { (receivedObject: User?) in
+              expect(receivedObject).toNot(beNil())
+              expectation2.fulfill()
+            }
+          }
+
+          self.waitForExpectationsWithTimeout(5.0, handler:nil)
+        }
+      }
+
       describe("#fileName") {
         it("returns a correct file name") {
           expect(storage.fileName(key)).to(equal(key.base64()))

--- a/Pod/Tests/Specs/Storage/MemoryStorageSpec.swift
+++ b/Pod/Tests/Specs/Storage/MemoryStorageSpec.swift
@@ -131,6 +131,38 @@ class MemoryStorageSpec: QuickSpec {
           self.waitForExpectationsWithTimeout(2.0, handler:nil)
         }
       }
+
+      describe("clearExpired") {
+        it("removes expired objects") {
+          let expectation1 = self.expectationWithDescription(
+            "Clear Expired Expectation 1")
+          let expectation2 = self.expectationWithDescription(
+            "Clear Expired Expectation 2")
+
+          let expiry1: Expiry = .Date(NSDate().dateByAddingTimeInterval(-100000))
+          let expiry2: Expiry = .Date(NSDate().dateByAddingTimeInterval(100000))
+
+          let key1 = "item1"
+          let key2 = "item2"
+
+          storage.add(key1, object: object, expiry: expiry1)
+          storage.add(key2, object: object, expiry: expiry2)
+
+          storage.clearExpired {
+            storage.object(key1) { (receivedObject: User?) in
+              expect(receivedObject).to(beNil())
+              expectation1.fulfill()
+            }
+
+            storage.object(key2) { (receivedObject: User?) in
+              expect(receivedObject).to(beNil())
+              expectation2.fulfill()
+            }
+          }
+
+          self.waitForExpectationsWithTimeout(5.0, handler:nil)
+        }
+      }
     }
   }
 }

--- a/Source/Cache/HybridCache.swift
+++ b/Source/Cache/HybridCache.swift
@@ -27,6 +27,10 @@ public class HybridCache {
       name: UIApplicationDidEnterBackgroundNotification, object: nil)
   }
 
+  deinit {
+    NSNotificationCenter.defaultCenter().removeObserver(self)
+  }
+
   // MARK: - Caching
 
   public func add<T: Cachable>(key: String, object: T, expiry: Expiry? = nil, completion: (() -> Void)? = nil) {

--- a/Source/Cache/HybridCache.swift
+++ b/Source/Cache/HybridCache.swift
@@ -90,15 +90,15 @@ public class HybridCache {
 
   // MARK: - Notifications
 
-  public func applicationDidReceiveMemoryWarning() {
+  func applicationDidReceiveMemoryWarning() {
     frontStorage.clearExpired(nil)
   }
 
-  public func applicationWillTerminate() {
+  func applicationWillTerminate() {
     backStorage.clearExpired(nil)
   }
 
-  public func applicationDidEnterBackground() {
+  func applicationDidEnterBackground() {
     let application = UIApplication.sharedApplication()
     var backgroundTask: UIBackgroundTaskIdentifier?
 

--- a/Source/Cache/HybridCache.swift
+++ b/Source/Cache/HybridCache.swift
@@ -16,6 +16,15 @@ public class HybridCache {
 
     frontStorage = StorageFactory.resolve(name, kind: config.frontKind, maxSize: config.maxSize)
     backStorage = StorageFactory.resolve(name, kind: config.backKind, maxSize: config.maxSize)
+
+    let notificationCenter = NSNotificationCenter.defaultCenter()
+
+    notificationCenter.addObserver(self, selector: "clearFrontStorage",
+      name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+    notificationCenter.addObserver(self, selector: "cleanExpiredCache",
+      name: UIApplicationWillTerminateNotification, object: nil)
+    notificationCenter.addObserver(self, selector: "backgroundCleanExpiredCache",
+      name: UIApplicationDidEnterBackgroundNotification, object: nil)
   }
 
   // MARK: - Caching

--- a/Source/Cache/HybridCache.swift
+++ b/Source/Cache/HybridCache.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 public class HybridCache {
 
@@ -86,5 +86,11 @@ public class HybridCache {
         completion?()
       }
     }
+  }
+
+  // MARK: - Notifications
+
+  public func clearFrontStorage() {
+    frontStorage.clear(nil)
   }
 }

--- a/Source/Storage/DiskStorage.swift
+++ b/Source/Storage/DiskStorage.swift
@@ -176,11 +176,11 @@ public class DiskStorage: StorageAware {
       if weakSelf.maxSize > 0 && totalSize > weakSelf.maxSize {
         let targetSize = weakSelf.maxSize / 2
 
-        let sortedFiles = objects.sort({
+        let sortedFiles = objects.sort {
           let time1 = ($0.resourceValues[NSURLContentModificationDateKey] as? NSDate)?.timeIntervalSince1970
           let time2 = ($1.resourceValues[NSURLContentModificationDateKey] as? NSDate)?.timeIntervalSince1970
           return time1 > time2
-        })
+        }
 
         for file in sortedFiles {
           do {

--- a/Source/Storage/DiskStorage.swift
+++ b/Source/Storage/DiskStorage.swift
@@ -42,7 +42,7 @@ public class DiskStorage: StorageAware {
         do {
           try weakSelf.fileManager.createDirectoryAtPath(weakSelf.path,
             withIntermediateDirectories: true, attributes: nil)
-        } catch _ {}
+        } catch {}
       }
 
       do {
@@ -52,7 +52,7 @@ public class DiskStorage: StorageAware {
         try weakSelf.fileManager.setAttributes(
           [NSFileModificationDate : expiry.date],
           ofItemAtPath: filePath)
-      } catch _ {}
+      } catch {}
 
       completion?()
     }
@@ -85,7 +85,7 @@ public class DiskStorage: StorageAware {
 
       do {
         try weakSelf.fileManager.removeItemAtPath(weakSelf.filePath(key))
-      } catch _ {}
+      } catch {}
 
       completion?()
     }
@@ -106,7 +106,7 @@ public class DiskStorage: StorageAware {
           where expiryDate.inThePast {
             try weakSelf.fileManager.removeItemAtPath(weakSelf.filePath(key))
         }
-      } catch _ {}
+      } catch {}
 
       completion?()
     }
@@ -121,7 +121,81 @@ public class DiskStorage: StorageAware {
 
       do {
         try weakSelf.fileManager.removeItemAtPath(weakSelf.path)
-      } catch _ {}
+      } catch {}
+
+      completion?()
+    }
+  }
+
+  public func clearExpired(completion: (() -> Void)? = nil) {
+    dispatch_async(writeQueue) { [weak self] in
+      guard let weakSelf = self else {
+        completion?()
+        return
+      }
+
+      let URL = NSURL(fileURLWithPath: weakSelf.path)
+      let resourceKeys = [NSURLIsDirectoryKey, NSURLContentModificationDateKey, NSURLTotalFileAllocatedSizeKey]
+      var objects = [(URL: NSURL, resourceValues: [NSObject: AnyObject])]()
+      var URLsToDelete = [NSURL]()
+      var totalSize: UInt = 0
+
+      guard let fileEnumerator = weakSelf.fileManager.enumeratorAtURL(URL, includingPropertiesForKeys: resourceKeys,
+        options: .SkipsHiddenFiles, errorHandler: nil), URLs = fileEnumerator.allObjects as? [NSURL] else {
+          completion?()
+          return
+      }
+
+      for fileURL in URLs {
+        do {
+          let resourceValues = try fileURL.resourceValuesForKeys(resourceKeys)
+
+          guard (resourceValues[NSURLIsDirectoryKey] as? NSNumber)?.boolValue == false else {
+            continue
+          }
+
+          if let expiryDate = resourceValues[NSURLContentModificationDateKey] as? NSDate
+            where expiryDate.inThePast {
+              URLsToDelete.append(fileURL)
+              continue
+          }
+
+          if let fileSize = resourceValues[NSURLTotalFileAllocatedSizeKey] as? NSNumber {
+            totalSize += fileSize.unsignedLongValue
+            objects.append((URL: fileURL, resourceValues: resourceValues))
+          }
+        } catch {}
+      }
+
+      for fileURL in URLsToDelete {
+        do {
+          try weakSelf.fileManager.removeItemAtURL(fileURL)
+        } catch {}
+      }
+
+      if weakSelf.maxSize > 0 && totalSize > weakSelf.maxSize {
+        let targetSize = weakSelf.maxSize / 2
+
+        let sortedFiles = objects.sort({
+          let time1 = ($0.resourceValues[NSURLContentModificationDateKey] as? NSDate)?.timeIntervalSince1970
+          let time2 = ($1.resourceValues[NSURLContentModificationDateKey] as? NSDate)?.timeIntervalSince1970
+          return time1 > time2
+        })
+
+        for file in sortedFiles {
+          do {
+            try weakSelf.fileManager.removeItemAtURL(file.URL)
+          } catch {}
+
+          if let fileSize = file.resourceValues[NSURLTotalFileAllocatedSizeKey] as? NSNumber {
+            totalSize -= fileSize.unsignedLongValue
+          }
+
+          if totalSize < targetSize {
+            break
+          }
+        }
+      }
 
       completion?()
     }

--- a/Source/Storage/MemoryStorage.swift
+++ b/Source/Storage/MemoryStorage.swift
@@ -98,6 +98,10 @@ public class MemoryStorage: StorageAware {
     }
   }
 
+  public func clearExpired(completion: (() -> Void)? = nil) {
+    clear(completion)
+  }
+
   // MARK: - Helpers
 
   func removeIfExpired(key: String, capsule: Capsule, completion: (() -> Void)? = nil) {

--- a/Source/Storage/StorageAware.swift
+++ b/Source/Storage/StorageAware.swift
@@ -7,6 +7,7 @@ public protocol CacheAware {
   func remove(key: String, completion: (() -> Void)?)
   func removeIfExpired(key: String, completion: (() -> Void)?)
   func clear(completion: (() -> Void)?)
+  func clearExpired(completion: (() -> Void)?)
 }
 
 public protocol StorageAware: CacheAware {


### PR DESCRIPTION
@zenangst @RamonGilabert 
Now we clear expired cache items when the application on of those notifications:
1) `UIApplicationDidReceiveMemoryWarningNotification`
2) `UIApplicationWillTerminateNotification`
3) `UIApplicationDidEnterBackgroundNotification`

<img width="200" alt="screen shot 2015-11-20 at 12 30 52" src="https://cloud.githubusercontent.com/assets/10529867/11565607/fb17052e-99de-11e5-9765-0f98ee307423.PNG">
