### PR TITLE
Fix: expiry date

### DIFF
--- a/Source/Shared/DataStructures/Expiry.swift
+++ b/Source/Shared/DataStructures/Expiry.swift
@@ -10,7 +10,7 @@ public enum Expiry {
 
     switch self {
     case .Never:
-      result = NSDate.distantFuture()
+      result = NSDate().dateByAddingTimeInterval(1000 * 60 * 60 * 24)
     case .Seconds(let seconds):
       result = NSDate().dateByAddingTimeInterval(seconds)
     case .Date(let date):

--- a/Tests/iOS/Specs/CacheSpec.swift
+++ b/Tests/iOS/Specs/CacheSpec.swift
@@ -30,7 +30,7 @@ class CacheSpec: QuickSpec {
 
           expect(cache.config.frontKind.name).to(equal(defaultConfig.frontKind.name))
           expect(cache.config.backKind.name).to(equal(defaultConfig.backKind.name))
-          expect(cache.config.expiry.date).to(equal(defaultConfig.expiry.date))
+          expect(cache.config.expiry.date.timeIntervalSinceNow) ≈ defaultConfig.expiry.date.timeIntervalSinceNow
           expect(cache.config.maxSize).to(equal(defaultConfig.maxSize))
         }
 

--- a/Tests/iOS/Specs/ConfigSpec.swift
+++ b/Tests/iOS/Specs/ConfigSpec.swift
@@ -13,7 +13,7 @@ class ConfigSpec: QuickSpec {
 
           expect(config.frontKind.name).to(equal(StorageKind.Memory.name))
           expect(config.backKind.name).to(equal(StorageKind.Disk.name))
-          expect(config.expiry.date).to(equal(Expiry.Never.date))
+          expect(config.expiry.date.timeIntervalSinceNow) ≈ Expiry.Never.date.timeIntervalSinceNow
           expect(config.maxSize).to(equal(0))
         }
       }

--- a/Tests/iOS/Specs/DataStructures/ExpirySpec.swift
+++ b/Tests/iOS/Specs/DataStructures/ExpirySpec.swift
@@ -10,10 +10,10 @@ class ExpirySpec: QuickSpec {
 
       describe("#date") {
         it("returns date in the distant future") {
-          let date = NSDate.distantFuture()
+          let date = NSDate().dateByAddingTimeInterval(1000 * 60 * 60 * 24)
           expiry = .Never
 
-          expect(expiry.date).to(equal(date))
+          expect(expiry.date.timeIntervalSinceNow) ≈ date.timeIntervalSinceNow
         }
 
         it("returns date by adding time interval") {

--- a/Tests/iOS/Specs/Storage/DiskStorageSpec.swift
+++ b/Tests/iOS/Specs/Storage/DiskStorageSpec.swift
@@ -117,13 +117,15 @@ class DiskStorageSpec: QuickSpec {
           let expectation = self.expectationWithDescription(
             "Don't Remove If Not Expired Expectation")
 
-          storage.add(key, object: object)
-          storage.removeIfExpired(key) {
-            storage.object(key) { (receivedObject: User?) in
-              expect(receivedObject).notTo(beNil())
-              expectation.fulfill()
+          storage.add(key, object: object) {
+            storage.removeIfExpired(key) {
+              storage.object(key) { (receivedObject: User?) in
+                expect(receivedObject).notTo(beNil())
+                expectation.fulfill()
+              }
             }
           }
+          
 
           self.waitForExpectationsWithTimeout(2.0, handler:nil)
         }


### PR DESCRIPTION
Don't use `NSDate.distantFuture()` due to http://lists.apple.com/archives/cocoa-dev/2005/Apr/msg01833.html. Now expiry `Never` is around 2.7 years which is enough I think.