### PR TITLE
Bugfix/cannot save file with long URL key

### DIFF
--- a/Cache.podspec
+++ b/Cache.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.tvos.source_files = 'Source/{iOS,Shared}/**/*'
 
   s.frameworks = 'Foundation'
-  s.dependency 'MD5'
+  s.dependency 'CryptoSwift'
 end

--- a/Cache.podspec
+++ b/Cache.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
   s.tvos.source_files = 'Source/{iOS,Shared}/**/*'
 
   s.frameworks = 'Foundation'
+  s.dependency 'MD5'
 end

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -658,6 +658,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/CryptoSwift.framework",
 			);
 			outputPaths = (
 			);

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		9ABAE0371CCF8FF7009477CF /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ABAE0361CCF8FF7009477CF /* CryptoSwift.framework */; };
-		9ABAE0391CCF9003009477CF /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ABAE0381CCF9003009477CF /* CryptoSwift.framework */; };
+		9AFE68041CCF982800B7C6AC /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AFE68031CCF982800B7C6AC /* Quick.framework */; };
+		9AFE68071CCF994A00B7C6AC /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AFE68051CCF986C00B7C6AC /* CryptoSwift.framework */; };
 		D5291C291C28220B00B702C9 /* UIImage+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C0D1C28220B00B702C9 /* UIImage+Cache.swift */; };
 		D5291C2D1C28220B00B702C9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C151C28220B00B702C9 /* Config.swift */; };
 		D5291C2E1C28220B00B702C9 /* Cachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C171C28220B00B702C9 /* Cachable.swift */; };
@@ -70,7 +71,6 @@
 		D5291D961C283CFB00B702C9 /* StorageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C271C28220B00B702C9 /* StorageFactory.swift */; };
 		D5291D9A1C283DB300B702C9 /* UIImage+CacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291D991C283DB300B702C9 /* UIImage+CacheSpec.swift */; };
 		D5291D9C1C283DD900B702C9 /* NSImage+CacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291D9B1C283DD900B702C9 /* NSImage+CacheSpec.swift */; };
-		D5291D9D1C283EC000B702C9 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5291CD91C2835D000B702C9 /* Quick.framework */; };
 		D5291D9E1C283EC000B702C9 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5291CDA1C2835D000B702C9 /* Nimble.framework */; };
 		D5291DA11C28405900B702C9 /* UIImage+CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291DA01C28405900B702C9 /* UIImage+CacheTests.swift */; };
 		D5291DA31C2841D200B702C9 /* NSImage+CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291DA21C2841D200B702C9 /* NSImage+CacheTests.swift */; };
@@ -95,7 +95,8 @@
 
 /* Begin PBXFileReference section */
 		9ABAE0361CCF8FF7009477CF /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/iOS/CryptoSwift.framework; sourceTree = "<group>"; };
-		9ABAE0381CCF9003009477CF /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/Mac/CryptoSwift.framework; sourceTree = "<group>"; };
+		9AFE68031CCF982800B7C6AC /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
+		9AFE68051CCF986C00B7C6AC /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/Mac/CryptoSwift.framework; sourceTree = "<group>"; };
 		D5291C0D1C28220B00B702C9 /* UIImage+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Cache.swift"; sourceTree = "<group>"; };
 		D5291C151C28220B00B702C9 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D5291C171C28220B00B702C9 /* Cachable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cachable.swift; sourceTree = "<group>"; };
@@ -115,7 +116,6 @@
 		D5291C6A1C2827FB00B702C9 /* BasicHybridCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicHybridCache.swift; sourceTree = "<group>"; };
 		D5291C6B1C2827FB00B702C9 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		D5291C721C28296B00B702C9 /* HybridCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HybridCache.swift; sourceTree = "<group>"; };
-		D5291CD91C2835D000B702C9 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
 		D5291CDA1C2835D000B702C9 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
 		D5291CDF1C28374800B702C9 /* SpecHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecHelper.swift; sourceTree = "<group>"; };
 		D5291CE01C28374800B702C9 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -168,6 +168,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AFE68071CCF994A00B7C6AC /* CryptoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -175,7 +176,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5291D9D1C283EC000B702C9 /* Quick.framework in Frameworks */,
 				D5291D9E1C283EC000B702C9 /* Nimble.framework in Frameworks */,
 				D5291D6A1C283B5400B702C9 /* Cache.framework in Frameworks */,
 			);
@@ -186,7 +186,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9ABAE0371CCF8FF7009477CF /* CryptoSwift.framework in Frameworks */,
-				9ABAE0391CCF9003009477CF /* CryptoSwift.framework in Frameworks */,
+				9AFE68041CCF982800B7C6AC /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -414,8 +414,8 @@
 		D5291DA51C28454000B702C9 /* Mac */ = {
 			isa = PBXGroup;
 			children = (
-				9ABAE0381CCF9003009477CF /* CryptoSwift.framework */,
-				D5291CD91C2835D000B702C9 /* Quick.framework */,
+				9AFE68051CCF986C00B7C6AC /* CryptoSwift.framework */,
+				9AFE68031CCF982800B7C6AC /* Quick.framework */,
 				D5291CDA1C2835D000B702C9 /* Nimble.framework */,
 			);
 			name = Mac;
@@ -674,6 +674,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/Mac/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/Nimble.framework",
+				"$(SRCROOT)/Carthage/Build/Mac/CryptoSwift.framework",
 			);
 			outputPaths = (
 			);
@@ -824,6 +825,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SRCROOT)/SupportFiles/Mac/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -845,6 +850,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SRCROOT)/SupportFiles/Mac/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9ABAE0371CCF8FF7009477CF /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ABAE0361CCF8FF7009477CF /* CryptoSwift.framework */; };
+		9ABAE0391CCF9003009477CF /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ABAE0381CCF9003009477CF /* CryptoSwift.framework */; };
 		D5291C291C28220B00B702C9 /* UIImage+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C0D1C28220B00B702C9 /* UIImage+Cache.swift */; };
 		D5291C2D1C28220B00B702C9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C151C28220B00B702C9 /* Config.swift */; };
 		D5291C2E1C28220B00B702C9 /* Cachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C171C28220B00B702C9 /* Cachable.swift */; };
@@ -92,6 +94,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9ABAE0361CCF8FF7009477CF /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/iOS/CryptoSwift.framework; sourceTree = "<group>"; };
+		9ABAE0381CCF9003009477CF /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/Mac/CryptoSwift.framework; sourceTree = "<group>"; };
 		D5291C0D1C28220B00B702C9 /* UIImage+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Cache.swift"; sourceTree = "<group>"; };
 		D5291C151C28220B00B702C9 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D5291C171C28220B00B702C9 /* Cachable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cachable.swift; sourceTree = "<group>"; };
@@ -181,6 +185,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9ABAE0371CCF8FF7009477CF /* CryptoSwift.framework in Frameworks */,
+				9ABAE0391CCF9003009477CF /* CryptoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -408,6 +414,7 @@
 		D5291DA51C28454000B702C9 /* Mac */ = {
 			isa = PBXGroup;
 			children = (
+				9ABAE0381CCF9003009477CF /* CryptoSwift.framework */,
 				D5291CD91C2835D000B702C9 /* Quick.framework */,
 				D5291CDA1C2835D000B702C9 /* Nimble.framework */,
 			);
@@ -417,6 +424,7 @@
 		D5291DA61C28454800B702C9 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				9ABAE0361CCF8FF7009477CF /* CryptoSwift.framework */,
 				D5DC5A6C1C205C2A003BD79B /* Quick.framework */,
 				D5DC5A6D1C205C2A003BD79B /* Nimble.framework */,
 			);
@@ -980,6 +988,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/SupportFiles/iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -997,6 +1010,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/SupportFiles/iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "3lvis/MD5" "master"
+github "krzyzanowskim/CryptoSwift" "master"

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "3lvis/MD5" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "Quick/Nimble" "v3.2.0"
-github "Quick/Quick" "v0.9.1"
+github "krzyzanowskim/CryptoSwift" "3f9ca1c1980fdc8e5c719d48ab81ae421b0497ee"
+github "Quick/Nimble" "v4.0.1"
+github "Quick/Quick" "v0.9.2"

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MD5
+import CryptoSwift
 
 public class DiskStorage: StorageAware {
 

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MD5
 
 public class DiskStorage: StorageAware {
 
@@ -204,7 +205,19 @@ public class DiskStorage: StorageAware {
   // MARK: - Helpers
 
   func fileName(key: String) -> String {
-    return key.base64()
+    if let digest = key.dataUsingEncoding(NSUTF8StringEncoding)?.md5() {
+      var string = ""
+      var byte: UInt8 = 0
+        
+      for i in 0 ..< digest.length {
+        digest.getBytes(&byte, range: NSMakeRange(i, 1))
+        string += String(format: "%02x", byte)
+      }
+        
+      return string
+    } else {
+      return key.base64()
+    }
   }
 
   func filePath(key: String) -> String {

--- a/Tests/iOS/Specs/Storage/DiskStorageSpec.swift
+++ b/Tests/iOS/Specs/Storage/DiskStorageSpec.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import CryptoSwift
 @testable import Cache
 
 class DiskStorageSpec: QuickSpec {
@@ -178,7 +179,19 @@ class DiskStorageSpec: QuickSpec {
 
       describe("#fileName") {
         it("returns a correct file name") {
-          expect(storage.fileName(key)).to(equal(key.base64()))
+          if let digest = key.dataUsingEncoding(NSUTF8StringEncoding)?.md5() {
+            var string = ""
+            var byte: UInt8 = 0
+                
+            for i in 0 ..< digest.length {
+              digest.getBytes(&byte, range: NSMakeRange(i, 1))
+              string += String(format: "%02x", byte)
+            }
+                
+            expect(storage.fileName(key)).to(equal(string))
+          } else {
+            expect(storage.fileName(key)).to(equal(key.base64()))
+          }
         }
       }
 


### PR DESCRIPTION
If you want to store an image (using Imaginary) in the disk storage and use the file’s remote URL as key, saving will fail if the URL is long. This PR tries to fix the issue by using the URL’s MD5 digest as file name instead of the Base64 encoded version of the URL