### PR TITLE
Improve memory handling

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,40 @@
+included: # paths to include during linting. `--path` is ignored if present.
+  - Source
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Carthage
+  - Pods
+
+# configurable rules can be customized from this configuration file
+# binary rules can set their severity level
+force_cast: warning # implicitly
+force_try:
+  severity: warning # explicitly
+# rules that have both warning and error levels, can set just the warning level
+# implicitly
+line_length: 200
+# they can set both implicitly with an array
+type_body_length:
+  - 300 # warning
+  - 400 # error
+# or they can set both explicitly
+file_length:
+  warning: 500
+  error: 1200
+# naming rules can set warnings/errors for min_length and max_length
+# additionally they can set excluded names
+type_name:
+  min_length: 3 # only warning
+  max_length: # warning and error
+    warning: 40
+    error: 50
+  excluded: iPhone # excluded via string
+variable_name:
+  min_length: # only min_length
+    error: 2 # only error
+  excluded: # excluded via string array
+    - x
+    - y
+    - id
+    - URL
+    - GlobalAPIKey
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 				D5291D5D1C283B5300B702C9 /* Headers */,
 				D5291D5E1C283B5300B702C9 /* Resources */,
 				D5BAEBF41CD1F4D30003E865 /* ShellScript */,
+				BD58C3AE1CF2EA04003F7141 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -584,6 +585,7 @@
 				D5DC59DD1C20593E003BD79B /* Headers */,
 				D5DC59DE1C20593E003BD79B /* Resources */,
 				D5BAEBF21CD1F4490003E865 /* ShellScript */,
+				BD58C3AD1CF2E9FD003F7141 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -670,6 +672,32 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		BD58C3AD1CF2E9FD003F7141 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		BD58C3AE1CF2EA04003F7141 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		D5291D591C283AA700B702C9 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Source/Mac/Extensions/NSImage+Cache.swift
+++ b/Source/Mac/Extensions/NSImage+Cache.swift
@@ -14,6 +14,7 @@ extension NSImage: Cachable {
    Creates UIImage from NSData
 
    - Parameter data: Data to decode from
+   - Returns: Optional CacheType
    */
   public static func decode(data: NSData) -> CacheType? {
     let image = NSImage(data: data)
@@ -22,6 +23,7 @@ extension NSImage: Cachable {
 
   /**
    Encodes UIImage to NSData
+   - Returns: Optional NSData
    */
   public func encode() -> NSData? {
     guard let data = TIFFRepresentation else { return nil }
@@ -45,7 +47,7 @@ extension NSImage {
    Checks if image has alpha component
    */
   var hasAlpha: Bool {
-    var imageRect:CGRect = CGRectMake(0, 0, size.width, size.height)
+    var imageRect: CGRect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
     let imageRef = CGImageForProposedRect(&imageRect, context: nil, hints: nil)
     let result: Bool
     let alpha = CGImageGetAlphaInfo(imageRef)

--- a/Source/Shared/BasicHybridCache.swift
+++ b/Source/Shared/BasicHybridCache.swift
@@ -28,7 +28,7 @@ public class BasicHybridCache: NSObject {
     self.name = name
     self.config = config
 
-    frontStorage = StorageFactory.resolve(name, kind: config.frontKind, maxSize: config.maxSize)
+    frontStorage = StorageFactory.resolve(name, kind: config.frontKind, maxSize: UInt(config.maxObjects))
     backStorage = StorageFactory.resolve(name, kind: config.backKind, maxSize: config.maxSize)
 
     super.init()

--- a/Source/Shared/Config.swift
+++ b/Source/Shared/Config.swift
@@ -10,8 +10,10 @@ public struct Config {
   /// Expiry date that will be applied by default for every added object
   /// if it's not overridden in the add(key: object: expiry: completion:) method
   public let expiry: Expiry
-  // Maximum size of the cache storage
+  /// Maximum size of the cache storage
   public let maxSize: UInt
+  /// Maximum amount of items to store in memory
+  public let maxObjects: Int
 
   // MARK: - Initialization
 
@@ -22,12 +24,14 @@ public struct Config {
    - Parameter backKind: Back cache type
    - Parameter expiry: Expiry date that will be applied by default for every added object
    - Parameter maxSize: Maximum size of the cache storage
+   - Parameter maxObjects: Maximum amount of objects to be stored in memory
    */
-  public init(frontKind: StorageKind, backKind: StorageKind, expiry: Expiry, maxSize: UInt) {
+  public init(frontKind: StorageKind, backKind: StorageKind, expiry: Expiry = .Never, maxSize: UInt = 0, maxObjects: Int = 0) {
     self.frontKind = frontKind
     self.backKind = backKind
     self.expiry = expiry
     self.maxSize = maxSize
+    self.maxObjects = maxObjects
   }
 }
 
@@ -41,8 +45,6 @@ extension Config {
   public static var defaultConfig: Config {
     return Config(
       frontKind: .Memory,
-      backKind: .Disk,
-      expiry: .Never,
-      maxSize: 0)
+      backKind: .Disk)
   }
 }

--- a/Source/Shared/Extensions/JSON+Cache.swift
+++ b/Source/Shared/Extensions/JSON+Cache.swift
@@ -13,15 +13,16 @@ extension JSON: Cachable {
    Creates JSON from NSData
 
    - Parameter data: Data to decode from
+   - Returns: An optional CacheType
    */
   public static func decode(data: NSData) -> CacheType? {
     var result: CacheType?
 
     do {
       let object = try NSJSONSerialization.JSONObjectWithData(data,
-        options: NSJSONReadingOptions())
+                                                              options: NSJSONReadingOptions())
 
-      switch (object) {
+      switch object {
       case let dictionary as [String : AnyObject]:
         result = JSON.Dictionary(dictionary)
       case let array as [AnyObject]:
@@ -36,6 +37,8 @@ extension JSON: Cachable {
 
   /**
    Encodes JSON to NSData
+
+   - Returns: Optional NSData
    */
   public func encode() -> NSData? {
     return try? NSJSONSerialization.dataWithJSONObject(object,

--- a/Source/Shared/Extensions/NSData+Cache.swift
+++ b/Source/Shared/Extensions/NSData+Cache.swift
@@ -13,6 +13,7 @@ extension NSData: Cachable {
    Creates an instance from NSData
 
    - Parameter data: Data to decode from
+   - Returns: An optional CacheType
    */
   public static func decode(data: NSData) -> CacheType? {
     return data
@@ -20,6 +21,7 @@ extension NSData: Cachable {
 
   /**
    Encodes an instance to NSData
+   - Returns: Optional NSData
    */
   public func encode() -> NSData? {
     return self

--- a/Source/Shared/Extensions/NSDate+Cache.swift
+++ b/Source/Shared/Extensions/NSDate+Cache.swift
@@ -13,6 +13,7 @@ extension NSDate: Cachable {
    Creates an instance from NSData
 
    - Parameter data: Data to decode from
+   - Returns: An optional CacheType
    */
   public static func decode(data: NSData) -> CacheType? {
     return NSKeyedUnarchiver.unarchiveObjectWithData(data) as? NSDate
@@ -20,6 +21,7 @@ extension NSDate: Cachable {
 
   /**
    Encodes an instance to NSData
+   - Returns: Optional NSData
    */
   public func encode() -> NSData? {
     return NSKeyedArchiver.archivedDataWithRootObject(self)

--- a/Source/Shared/Extensions/String+Cache.swift
+++ b/Source/Shared/Extensions/String+Cache.swift
@@ -13,6 +13,7 @@ extension String: Cachable {
    Creates a string from NSData
 
    - Parameter data: Data to decode from
+   - Returns: An optional CacheType
    */
   public static func decode(data: NSData) -> CacheType? {
     guard let string = String(data: data, encoding: NSUTF8StringEncoding) else {
@@ -24,6 +25,7 @@ extension String: Cachable {
 
   /**
    Encodes a string to NSData
+   - Returns: Optional NSData
    */
   public func encode() -> NSData? {
     return dataUsingEncoding(NSUTF8StringEncoding)
@@ -39,6 +41,8 @@ extension String {
 
   /**
    Creates base64 string
+
+   - Returns: A base64 encoded string
    */
   func base64() -> String {
     guard let data = self.dataUsingEncoding(NSUTF8StringEncoding) else { return self }

--- a/Source/Shared/Library/DefaultCacheConverter.swift
+++ b/Source/Shared/Library/DefaultCacheConverter.swift
@@ -23,6 +23,7 @@ public struct DefaultCacheConverter<T> {
    Creates an instance from NSData
 
    - Parameter data: Data to decode from
+   - Returns: A generic type or throws
    */
   public func decode(data: NSData) throws -> T {
     guard data.length == sizeof(T) else {
@@ -37,6 +38,9 @@ public struct DefaultCacheConverter<T> {
 
   /**
    Encodes an instance to NSData
+
+   - Parameter value: A generic value
+   - Returns: A NSData or throws
    */
   public func encode(value: T) throws -> NSData {
     var value = value

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -98,7 +98,7 @@ public class DiskStorage: StorageAware {
       let filePath = weakSelf.filePath(key)
       var cachedObject: T?
 
-      if let data = NSData(contentsOfFile: filePath)  {
+      if let data = NSData(contentsOfFile: filePath) {
         cachedObject = T.decode(data) as? T
       }
 
@@ -259,6 +259,7 @@ public class DiskStorage: StorageAware {
    Builds file name from the key.
 
    - Parameter key: Unique key to identify the object in the cache
+   - Returns: A md5 or base64 string
    */
   func fileName(key: String) -> String {
     if let digest = key.dataUsingEncoding(NSUTF8StringEncoding)?.md5() {
@@ -266,7 +267,7 @@ public class DiskStorage: StorageAware {
       var byte: UInt8 = 0
 
       for i in 0 ..< digest.length {
-        digest.getBytes(&byte, range: NSMakeRange(i, 1))
+        digest.getBytes(&byte, range: NSRange(location: i, length: 1))
         string += String(format: "%02x", byte)
       }
 
@@ -280,6 +281,7 @@ public class DiskStorage: StorageAware {
    Builds file path from the key.
 
    - Parameter key: Unique key to identify the object in the cache
+   - Returns: A string path based on key
    */
   func filePath(key: String) -> String {
     return "\(path)/\(fileName(key))"

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -14,11 +14,7 @@ public class MemoryStorage: StorageAware {
   }
 
   /// Maximum size of the cache storage
-  public var maxSize: UInt {
-    didSet(value) {
-      self.cache.totalCostLimit = Int(maxSize)
-    }
-  }
+  public var maxSize: UInt
 
   /// Memory cache instance
   public let cache = NSCache()
@@ -37,6 +33,9 @@ public class MemoryStorage: StorageAware {
    */
   public required init(name: String, maxSize: UInt = 0) {
     self.maxSize = maxSize
+
+    cache.countLimit = Int(maxSize)
+    cache.totalCostLimit = Int(maxSize)
     cache.name = "\(MemoryStorage.prefix).\(name.capitalizedString)"
     writeQueue = dispatch_queue_create("\(cache.name).WriteQueue", DISPATCH_QUEUE_SERIAL)
     readQueue = dispatch_queue_create("\(cache.name).ReadQueue", DISPATCH_QUEUE_SERIAL)

--- a/Source/iOS/Extensions/UIImage+Cache.swift
+++ b/Source/iOS/Extensions/UIImage+Cache.swift
@@ -13,6 +13,7 @@ extension UIImage: Cachable {
    Creates UIImage from NSData
 
    - Parameter data: Data to decode from
+   - Returns: An optional share type
    */
   public static func decode(data: NSData) -> CacheType? {
     let image = UIImage(data: data)
@@ -21,6 +22,8 @@ extension UIImage: Cachable {
 
   /**
    Encodes UIImage to NSData
+
+   - Returns: Optional NSData
    */
   public func encode() -> NSData? {
     return hasAlpha

--- a/Source/iOS/HybridCache.swift
+++ b/Source/iOS/HybridCache.swift
@@ -59,22 +59,25 @@ public class HybridCache: BasicHybridCache {
     var backgroundTask: UIBackgroundTaskIdentifier?
 
     backgroundTask = application.beginBackgroundTaskWithExpirationHandler { [weak self] in
-      guard let weakSelf = self, var backgroundTask = backgroundTask else { return }
+      guard let weakSelf = self, backgroundTask = backgroundTask else { return }
+      var mutableBackgroundTask = backgroundTask
 
-      weakSelf.endBackgroundTask(&backgroundTask)
+      weakSelf.endBackgroundTask(&mutableBackgroundTask)
     }
 
     backStorage.clearExpired { [weak self] in
-      guard let weakSelf = self, var backgroundTask = backgroundTask else { return }
+      guard let weakSelf = self, backgroundTask = backgroundTask else { return }
+      var mutableBackgroundTask = backgroundTask
 
       dispatch_async(dispatch_get_main_queue()) {
-        weakSelf.endBackgroundTask(&backgroundTask)
+        weakSelf.endBackgroundTask(&mutableBackgroundTask)
       }
     }
   }
 
   /**
    Ends given background task.
+   - Parameter task: A UIBackgroundTaskIdentifier
    */
   func endBackgroundTask(inout task: UIBackgroundTaskIdentifier) {
     UIApplication.sharedApplication().endBackgroundTask(task)


### PR DESCRIPTION
This PR aims to improve the memory handling when using Cache.

Before, we shared the same variable for `DiskStorage` and `MemoryStorage` which ended up not being what we want. And here is why:

`DiskStorage`’s limit is based on actual disk space where as `MemoryStorage` is based on the amount of objects that you want to keep in memory.

So this PR adds another variable to the configuration called `maxObjects`, it defaults to `0` so that it does not break the current implementations but the components using `Cache` now gain more fine-grained control over both storages.

Also, internally inside `didSet` in `MemoryStorage` but it was never called because it was only called inside `init`. 

As and added bonus, this PR also adds SwiftLint and fixes some of the warnings that it introduces.

With `Imaginary` this change made quiet an impact on memory usage;

### Before
<img width="298" alt="screen shot 2016-05-23 at 11 01 49" src="https://cloud.githubusercontent.com/assets/57446/15466082/1abe45c4-20d8-11e6-8f81-d41162fd82f1.PNG">

### After
<img width="300" alt="screen shot 2016-05-23 at 11 04 26" src="https://cloud.githubusercontent.com/assets/57446/15466086/2004189c-20d8-11e6-837f-880f8153189b.PNG">
