### PR TITLE
Feature/config for json serialization

### DIFF
--- a/Source/Shared/Extensions/JSON+Cache.swift
+++ b/Source/Shared/Extensions/JSON+Cache.swift
@@ -26,7 +26,7 @@ extension JSON: Cachable {
 
     do {
       let object = try NSJSONSerialization.JSONObjectWithData(data,
-                                                              options: NSJSONReadingOptions())
+                                                              options: CacheJSONOptions.readingOptions)
 
       switch object {
       case let dictionary as [String : AnyObject]:
@@ -48,6 +48,6 @@ extension JSON: Cachable {
    */
   public func encode() -> NSData? {
     return try? NSJSONSerialization.dataWithJSONObject(object,
-      options: NSJSONWritingOptions())
+      options: CacheJSONOptions.writeOptions)
   }
 }

--- a/Source/Shared/Extensions/JSON+Cache.swift
+++ b/Source/Shared/Extensions/JSON+Cache.swift
@@ -1,15 +1,18 @@
 import Foundation
 
+/// A configuration struct
+public struct CacheJSONOptions {
+  /// Options used when creating Foundation objects from JSON data
+  public static var readingOptions: NSJSONReadingOptions = NSJSONReadingOptions()
+  /// Options for writing JSON data.
+  public static var writeOptions: NSJSONWritingOptions = NSJSONWritingOptions()
+}
+
 // MARK: - Cachable
 
 /**
  Implementation of Cachable protocol.
  */
-
-public struct CacheJSONOptions {
-  public static var readingOptions: NSJSONReadingOptions = NSJSONReadingOptions()
-  public static var writeOptions: NSJSONWritingOptions = NSJSONWritingOptions()
-}
 
 extension JSON: Cachable {
 

--- a/Source/Shared/Extensions/JSON+Cache.swift
+++ b/Source/Shared/Extensions/JSON+Cache.swift
@@ -5,6 +5,12 @@ import Foundation
 /**
  Implementation of Cachable protocol.
  */
+
+public struct CacheJSONOptions {
+  public static var readingOptions: NSJSONReadingOptions = NSJSONReadingOptions()
+  public static var writeOptions: NSJSONWritingOptions = NSJSONWritingOptions()
+}
+
 extension JSON: Cachable {
 
   public typealias CacheType = JSON

--- a/Source/Shared/Extensions/JSON+Cache.swift
+++ b/Source/Shared/Extensions/JSON+Cache.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// A configuration struct
-public struct CacheJSONOptions {
+/// A configuration enum
+public enum CacheJSONOptions {
   /// Options used when creating Foundation objects from JSON data
   public static var readingOptions: NSJSONReadingOptions = NSJSONReadingOptions()
   /// Options for writing JSON data.

--- a/Source/Shared/Extensions/JSON+Cache.swift
+++ b/Source/Shared/Extensions/JSON+Cache.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// A configuration enum
-public enum CacheJSONOptions {
+/// A configuration struct
+public struct CacheJSONOptions {
   /// Options used when creating Foundation objects from JSON data
   public static var readingOptions: NSJSONReadingOptions = NSJSONReadingOptions()
   /// Options for writing JSON data.


### PR DESCRIPTION
This PR adds configuration options for NSJSONSerialization.

It can be configured like this;

```swift
CacheJSONOptions.writeOptions = .PrettyPrinted
```