### PR TITLE
Expose backStorage path in public API

### DIFF
--- a/Source/Shared/BasicHybridCache.swift
+++ b/Source/Shared/BasicHybridCache.swift
@@ -16,6 +16,10 @@ public class BasicHybridCache: NSObject {
   // BAck cache (used for content that outlives the application life-cycle)
   var backStorage: StorageAware
 
+  public var path: String {
+    return backStorage.path
+  }
+
   // MARK: - Inititalization
 
   /**


### PR DESCRIPTION
This PR opens up for reading the `backStorage.path` when creating a cache. This is useful when you need to locate a specific cache path, maybe for removing individually or when monitoring the cache.