### PR TITLE
Removed script which copied the framework - Carthage suggests it should be done at app level.

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -584,7 +584,6 @@
 				D5DC59DC1C20593E003BD79B /* Frameworks */,
 				D5DC59DD1C20593E003BD79B /* Headers */,
 				D5DC59DE1C20593E003BD79B /* Resources */,
-				D5BAEBF21CD1F4490003E865 /* ShellScript */,
 				BD58C3AD1CF2E9FD003F7141 /* ShellScript */,
 			);
 			buildRules = (
@@ -723,20 +722,6 @@
 				"$(SRCROOT)/Carthage/Build/Mac/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/Nimble.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/CryptoSwift.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		D5BAEBF21CD1F4490003E865 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/CryptoSwift.framework",
 			);
 			outputPaths = (
 			);


### PR DESCRIPTION
Carthage states it should be don on the app level not framework level.
Without this i was getting ITMS-90205 and ITMS-90206 during upload to the App Store.
See:

https://github.com/MattCheetham/HarvestKit-Swift/pull/91
https://github.com/Carthage/Carthage/issues/353
https://github.com/Carthage/Carthage/issues/416