### PR TITLE
Added Swift 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: objective-c
 
+env:
+  global:
+  - LC_CTYPE=en_US.UTF-8
+  - LANG=en_US.UTF-8
+  - OSX_SIM="macosx"
+  - IOS_SIM="iphonesimulator"
+
 matrix:
   include:
     - os: osx
@@ -21,7 +28,7 @@ before_install:
 - travis_wait 35 carthage bootstrap --platform Mac,iOS
 
 script:
-- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-Mac" -sdk macosx -destination "$DESTINATION"
-- xcodebuild test -project Cache.xcodeproj -scheme "Cache-Mac" -sdk macosx -destination "$DESTINATION"
-- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-iOS" -sdk iphonesimulator -destination "$DESTINATION"
-- xcodebuild test -project Cache.xcodeproj -scheme "Cache-iOS" -sdk iphonesimulator -destination "$DESTINATION"
+- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-Mac" -sdk "$SDK" -destination "$DESTINATION"
+- xcodebuild test -project Cache.xcodeproj -scheme "Cache-Mac" -sdk "$SDK" -destination "$DESTINATION"
+- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-iOS" -sdk "$SDK" -destination "$DESTINATION"
+- xcodebuild test -project Cache.xcodeproj -scheme "Cache-iOS" -sdk "$SDK" -destination "$DESTINATION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
-osx_image: xcode7.3
 language: objective-c
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode8
 
 before_install:
 - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ matrix:
   include:
     - os: osx
       osx_image: xcode7.3
-      env: DESTINATION="arch=x86_64" SDK="${OSX_SIM}10.11"
+      env: DESTINATION="arch=x86_64" SDK="${OSX_SIM}" SCHEME="Cache-Mac"
     - os: osx
       osx_image: xcode7.3
-      env: DESTINATION="OS=9.2,name=iPhone 6S" SDK="${IOS_SIM}9.3"
+      env: DESTINATION="OS=9.2,name=iPhone 6S" SDK="${IOS_SIM}9.3" SCHEME="Cache-iOS"
     - os: osx
       osx_image: xcode8
-      env: DESTINATION="arch=x86_64" SDK="${OSX_SIM}10.12"
+      env: DESTINATION="arch=x86_64" SDK="${OSX_SIM}" SCHEME="Cache-Mac"
     - os: osx
       osx_image: xcode8
-      env: DESTINATION="OS=10.0,name=iPhone 6S" SDK="${IOS_SIM}10.0"
+      env: DESTINATION="OS=10.0,name=iPhone 6S" SDK="${IOS_SIM}10.0" SCHEME="Cache-iOS"
 
 before_install:
 - brew update
@@ -28,7 +28,5 @@ before_install:
 - travis_wait 35 carthage bootstrap --platform Mac,iOS
 
 script:
-- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-Mac" -sdk "$SDK" -destination "$DESTINATION"
-- xcodebuild test -project Cache.xcodeproj -scheme "Cache-Mac" -sdk "$SDK" -destination "$DESTINATION"
-- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-iOS" -sdk "$SDK" -destination "$DESTINATION"
-- xcodebuild test -project Cache.xcodeproj -scheme "Cache-iOS" -sdk "$SDK" -destination "$DESTINATION"
+- xcodebuild clean build -project Cache.xcodeproj -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
+- xcodebuild test -project Cache.xcodeproj -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,16 @@ matrix:
   include:
     - os: osx
       osx_image: xcode7.3
+      env: DESTINATION="arch=x86_64" SDK="${OSX_SIM}10.11"
+    - os: osx
+      osx_image: xcode7.3
+      env: DESTINATION="OS=9.2,name=iPhone 6S" SDK="${IOS_SIM}9.3"
     - os: osx
       osx_image: xcode8
+      env: DESTINATION="arch=x86_64" SDK="${OSX_SIM}10.12"
+    - os: osx
+      osx_image: xcode8
+      env: DESTINATION="OS=10.0,name=iPhone 6S" SDK="${IOS_SIM}10.0"
 
 before_install:
 - brew update
@@ -13,7 +21,7 @@ before_install:
 - travis_wait 35 carthage bootstrap --platform Mac,iOS
 
 script:
-- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-Mac" -sdk macosx
-- xcodebuild test -project Cache.xcodeproj -scheme "Cache-Mac" -sdk macosx
-- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-iOS" -sdk iphonesimulator
-- xcodebuild test -project Cache.xcodeproj -scheme "Cache-iOS" -sdk iphonesimulator
+- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-Mac" -sdk macosx -destination "$DESTINATION"
+- xcodebuild test -project Cache.xcodeproj -scheme "Cache-Mac" -sdk macosx -destination "$DESTINATION"
+- xcodebuild clean build -project Cache.xcodeproj -scheme "Cache-iOS" -sdk iphonesimulator -destination "$DESTINATION"
+- xcodebuild test -project Cache.xcodeproj -scheme "Cache-iOS" -sdk iphonesimulator -destination "$DESTINATION"

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -607,6 +607,7 @@
 				TargetAttributes = {
 					D5291D171C2837DB00B702C9 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					D5291D5F1C283B5300B702C9 = {
 						CreatedOnToolsVersion = 7.2;
@@ -616,6 +617,7 @@
 					};
 					D5DC59DF1C20593E003BD79B = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -866,6 +868,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Cache-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -880,6 +883,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Cache-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -905,6 +909,7 @@
 				PRODUCT_NAME = Cache;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -930,6 +935,7 @@
 				PRODUCT_NAME = Cache;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -948,6 +954,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Cache-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -966,6 +973,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Cache-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -1077,6 +1085,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Cache;
 				PRODUCT_NAME = Cache;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -1099,6 +1108,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Cache;
 				PRODUCT_NAME = Cache;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "krzyzanowskim/CryptoSwift"
+github "krzyzanowskim/CryptoSwift" "swift2"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "krzyzanowskim/CryptoSwift" "swift2"
+github "sumolari/CryptoSwift" "swift-2.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "krzyzanowskim/CryptoSwift" "f70ef81477628c9d3e1f72f93dd8c7e7ce6980bd"
+github "sumolari/CryptoSwift" "fcc2d6b38e4fcd601b08d71eb2eb24d16fce34d0"
 github "Quick/Nimble" "v4.1.0"
 github "Quick/Quick" "v0.9.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "krzyzanowskim/CryptoSwift" "3a0c3153717070a42971c30cd73d67f6f832f4bc"
-github "Quick/Nimble" "v4.0.1"
-github "Quick/Quick" "v0.9.2"
+github "krzyzanowskim/CryptoSwift" "f70ef81477628c9d3e1f72f93dd8c7e7ce6980bd"
+github "Quick/Nimble" "v4.1.0"
+github "Quick/Quick" "v0.9.3"

--- a/Source/Mac/Extensions/NSImage+Cache.swift
+++ b/Source/Mac/Extensions/NSImage+Cache.swift
@@ -28,10 +28,16 @@ extension NSImage: Cachable {
   public func encode() -> NSData? {
     guard let data = TIFFRepresentation else { return nil }
 
+    #if swift(>=2.3)
+    let imageFileType: NSBitmapImageFileType = hasAlpha
+      ? .PNG
+      : .JPEG
+    #else
     let imageFileType: NSBitmapImageFileType = hasAlpha
       ? .NSPNGFileType
       : .NSJPEGFileType
-
+    #endif
+        
     return NSBitmapImageRep(data: data)?.representationUsingType(imageFileType, properties: [:])
   }
 }
@@ -50,7 +56,17 @@ extension NSImage {
     var imageRect: CGRect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
     let imageRef = CGImageForProposedRect(&imageRect, context: nil, hints: nil)
     let result: Bool
+    
+    #if swift(>=2.3)
+    let alpha: CGImageAlphaInfo
+    if let image = imageRef {
+        alpha = CGImageGetAlphaInfo(image)
+    } else {
+        alpha = .None
+    }
+    #else
     let alpha = CGImageGetAlphaInfo(imageRef)
+    #endif
 
     switch alpha {
     case .None, .NoneSkipFirst, .NoneSkipLast:

--- a/Source/iOS/Extensions/UIImage+Cache.swift
+++ b/Source/iOS/Extensions/UIImage+Cache.swift
@@ -44,7 +44,16 @@ extension UIImage {
    */
   var hasAlpha: Bool {
     let result: Bool
+    #if swift(>=2.3)
+    let alpha: CGImageAlphaInfo
+    if let image = CGImage {
+        alpha = CGImageGetAlphaInfo(image)
+    } else {
+        alpha = .None
+    }
+    #else
     let alpha = CGImageGetAlphaInfo(CGImage)
+    #endif
 
     switch alpha {
     case .None, .NoneSkipFirst, .NoneSkipLast:

--- a/Tests/Mac/Helpers/NSImage+CacheTests.swift
+++ b/Tests/Mac/Helpers/NSImage+CacheTests.swift
@@ -10,9 +10,15 @@ extension NSImage {
   var data: NSData {
     let representation = TIFFRepresentation!
 
+    #if swift(>=2.3)
+    let imageFileType: NSBitmapImageFileType = hasAlpha
+      ? .PNG
+      : .JPEG
+    #else
     let imageFileType: NSBitmapImageFileType = hasAlpha
       ? .NSPNGFileType
       : .NSJPEGFileType
+    #endif
 
     return (NSBitmapImageRep(data: representation)?.representationUsingType(
       imageFileType, properties: [:]))!

--- a/Tests/Mac/Specs/Extensions/NSImage+CacheSpec.swift
+++ b/Tests/Mac/Specs/Extensions/NSImage+CacheSpec.swift
@@ -23,9 +23,15 @@ class NSImageCacheSpec: QuickSpec {
             let image = SpecHelper.image()
             let representation = image.TIFFRepresentation!
 
+            #if swift(>=2.3)
+            let imageFileType: NSBitmapImageFileType = image.hasAlpha
+              ? .PNG
+              : .JPEG
+            #else
             let imageFileType: NSBitmapImageFileType = image.hasAlpha
               ? .NSPNGFileType
               : .NSJPEGFileType
+            #endif
 
             let data = NSBitmapImageRep(data: representation)!.representationUsingType(
               imageFileType, properties: [:])

--- a/Tests/iOS/Helpers/SpecHelper.swift
+++ b/Tests/iOS/Helpers/SpecHelper.swift
@@ -16,12 +16,21 @@ struct SpecHelper {
       UIGraphicsBeginImageContextWithOptions(size, opaque, 0)
       let context = UIGraphicsGetCurrentContext()
 
+      #if swift(>=2.3)
+      CGContextSetFillColorWithColor(context!, color.CGColor)
+      CGContextFillRect(context!, CGRectMake(0, 0, size.width, size.height))
+      #else
       CGContextSetFillColorWithColor(context, color.CGColor)
       CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height))
+      #endif
 
       let image = UIGraphicsGetImageFromCurrentImageContext()
       UIGraphicsEndImageContext()
 
+      #if swift(>=2.3)
+      return image!
+      #else
       return image
+      #endif
   }
 }

--- a/Tests/iOS/Helpers/UIImage+CacheTests.swift
+++ b/Tests/iOS/Helpers/UIImage+CacheTests.swift
@@ -19,6 +19,10 @@ extension UIImage {
     let drawnImage = UIGraphicsGetImageFromCurrentImageContext()
     UIGraphicsEndImageContext()
 
+    #if swift(>=2.3)
+    return CGDataProviderCopyData(CGImageGetDataProvider(drawnImage!.CGImage!)!)!
+    #else
     return CGDataProviderCopyData(CGImageGetDataProvider(drawnImage.CGImage))!
+    #endif
   }
 }

--- a/Tests/iOS/Specs/DataStructures/ExpirySpec.swift
+++ b/Tests/iOS/Specs/DataStructures/ExpirySpec.swift
@@ -20,7 +20,7 @@ class ExpirySpec: QuickSpec {
           let date = NSDate().dateByAddingTimeInterval(1000)
           expiry = .Seconds(1000)
 
-          expect(expiry.date.timeIntervalSince1970) ≈ (date.timeIntervalSince1970, 0.01)
+          expect(expiry.date.timeIntervalSince1970).to(beCloseTo(date.timeIntervalSince1970, within: 0.01))
         }
 
         it("returns specified date") {


### PR DESCRIPTION
This adds support for Swift 2.3 and extends test environments to include Xcode 8.

Main changes are some constants renamed in Swift 2.3 and a dependency update.

Results of new test environments: [![Build Status](https://travis-ci.org/Sumolari/Cache.svg?branch=swift-2.3)](https://travis-ci.org/Sumolari/Cache)