### PR TITLE
Add codecov.io to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ script:
 
 notifications:
   email: false
+
+after_success:
+- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR adds codecov.io to `Cache`.