### PR TITLE
Allow for the disk cache to be stored in a different location

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ let config = Config(
   // if it's not overridden in the add(key: object: expiry: completion:) method
   expiry: .date(Date().addingTimeInterval(100000)),
   // Maximum size of your cache storage
-  maxSize: 10000)
+  maxSize: 10000,
+  // where to store the disk cache. If nil, it is placed in an automatically generated directory in Caches
+  cacheDirectory: NSSearchPathForDirectoriesInDomains(.documentDirectory,
+                                                      FileManager.SearchPathDomainMask.userDomainMask,
+                                                      true).first! + "/cache-in-documents"
+)
 
 let cache = HybridCache(name: "Custom", config: config)
 ```

--- a/Source/Shared/BasicHybridCache.swift
+++ b/Source/Shared/BasicHybridCache.swift
@@ -33,7 +33,7 @@ public class BasicHybridCache: NSObject {
     self.config = config
 
     frontStorage = StorageFactory.resolve(name, kind: config.frontKind, maxSize: UInt(config.maxObjects))
-    backStorage = StorageFactory.resolve(name, kind: config.backKind, maxSize: config.maxSize)
+    backStorage = StorageFactory.resolve(name, kind: config.backKind, maxSize: config.maxSize, cacheDirectory: config.cacheDirectory)
 
     super.init()
   }

--- a/Source/Shared/Config.swift
+++ b/Source/Shared/Config.swift
@@ -14,6 +14,8 @@ public struct Config {
   public let maxSize: UInt
   /// Maximum amount of items to store in memory
   public let maxObjects: Int
+  /// (optional) A folder to store the disk cache contents. Defaults to a prefixed directory in Caches if nil
+  public let cacheDirectory: String?
 
   // MARK: - Initialization
 
@@ -26,12 +28,13 @@ public struct Config {
    - Parameter maxSize: Maximum size of the cache storage
    - Parameter maxObjects: Maximum amount of objects to be stored in memory
    */
-  public init(frontKind: StorageKind, backKind: StorageKind, expiry: Expiry = .never, maxSize: UInt = 0, maxObjects: Int = 0) {
+  public init(frontKind: StorageKind, backKind: StorageKind, expiry: Expiry = .never, maxSize: UInt = 0, maxObjects: Int = 0, cacheDirectory: String? = nil) {
     self.frontKind = frontKind
     self.backKind = backKind
     self.expiry = expiry
     self.maxSize = maxSize
     self.maxObjects = maxObjects
+    self.cacheDirectory = cacheDirectory
   }
 }
 

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -32,13 +32,20 @@ public final class DiskStorage: StorageAware {
    - Parameter name: A name of the storage
    - Parameter maxSize: Maximum size of the cache storage
    */
-  public required init(name: String, maxSize: UInt = 0) {
+    public required init(name: String, maxSize: UInt = 0, cacheDirectory: String? = nil) {
     self.maxSize = maxSize
     let cacheName = name.capitalized
-    let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
-      FileManager.SearchPathDomainMask.userDomainMask, true)
 
-    path = "\(paths.first!)/\(DiskStorage.prefix).\(cacheName)"
+    if let storageLocation = cacheDirectory {
+      path = storageLocation
+    }
+    else {
+      let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
+                                                      FileManager.SearchPathDomainMask.userDomainMask, true)
+        
+      path = "\(paths.first!)/\(DiskStorage.prefix).\(cacheName)"
+    }
+
     writeQueue = DispatchQueue(label: "\(DiskStorage.prefix).\(cacheName).WriteQueue",
       attributes: [])
     readQueue = DispatchQueue(label: "\(DiskStorage.prefix).\(cacheName).ReadQueue",

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -31,7 +31,7 @@ public final class MemoryStorage: StorageAware {
    - Parameter name: A name of the storage
    - Parameter maxSize: Maximum size of the cache storage
    */
-  public required init(name: String, maxSize: UInt = 0) {
+  public required init(name: String, maxSize: UInt = 0, cacheDirectory: String? = nil) {
     self.maxSize = maxSize
 
     cache.countLimit = Int(maxSize)

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -75,6 +75,7 @@ public protocol StorageAware: CacheAware {
 
    - Parameter name: A name of the storage
    - Parameter maxSize: Maximum size of the cache storage
+   - Parameter cacheDirectory: (optional) A folder to store the disk cache contents. Defaults to a prefixed directory in Caches
    */
-  init(name: String, maxSize: UInt)
+  init(name: String, maxSize: UInt, cacheDirectory: String?)
 }

--- a/Source/Shared/Storage/StorageFactory.swift
+++ b/Source/Shared/Storage/StorageFactory.swift
@@ -35,9 +35,9 @@ public final class StorageFactory {
    - Parameter maxSize: Maximum size of the cache storage
    - Returns: New storage
    */
-  static func resolve(_ name: String, kind: StorageKind, maxSize: UInt = 0) -> StorageAware {
+  static func resolve(_ name: String, kind: StorageKind, maxSize: UInt = 0, cacheDirectory: String? = nil) -> StorageAware {
     let StorageType: StorageAware.Type = storages[kind.name] ?? DefaultStorage
-    return StorageType.init(name: name, maxSize: maxSize)
+    return StorageType.init(name: name, maxSize: maxSize, cacheDirectory: cacheDirectory)
   }
 
   /**


### PR DESCRIPTION
This PR adds another option to Config to allow the user to place the cache in a different directory.

My use case for this is that I want to use Cache to enable an offline mode for my app and it isn't acceptable to have the disk cache susceptible to deletion at Apple's whim in the Caches directory.