### PR TITLE
Add document permanent storage

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		64A161061E871A08000148A3 /* PermanentDiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64A161051E871A08000148A3 /* PermanentDiskStorage.swift */; };
+		64A161071E871A10000148A3 /* PermanentDiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64A161051E871A08000148A3 /* PermanentDiskStorage.swift */; };
+		64A161081E871A11000148A3 /* PermanentDiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64A161051E871A08000148A3 /* PermanentDiskStorage.swift */; };
 		BDEDD35E1DBCE5C7007416A6 /* HybridCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C721C28296B00B702C9 /* HybridCache.swift */; };
 		BDEDD35F1DBCE5CA007416A6 /* UIImage+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C0D1C28220B00B702C9 /* UIImage+Cache.swift */; };
 		BDEDD3601DBCE5CE007416A6 /* BasicHybridCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C6A1C2827FB00B702C9 /* BasicHybridCache.swift */; };
@@ -143,6 +146,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		64A161051E871A08000148A3 /* PermanentDiskStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermanentDiskStorage.swift; sourceTree = "<group>"; };
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5291C0D1C28220B00B702C9 /* UIImage+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Cache.swift"; sourceTree = "<group>"; };
@@ -328,6 +332,7 @@
 			isa = PBXGroup;
 			children = (
 				D5291C241C28220B00B702C9 /* DiskStorage.swift */,
+				64A161051E871A08000148A3 /* PermanentDiskStorage.swift */,
 				D5291C251C28220B00B702C9 /* MemoryStorage.swift */,
 				D5291C261C28220B00B702C9 /* StorageAware.swift */,
 				D5291C271C28220B00B702C9 /* StorageFactory.swift */,
@@ -848,6 +853,7 @@
 				BDEDD3651DBCE5D8007416A6 /* Expiry.swift in Sources */,
 				BDEDD3631DBCE5D8007416A6 /* Cachable.swift in Sources */,
 				BDEDD35F1DBCE5CA007416A6 /* UIImage+Cache.swift in Sources */,
+				64A161081E871A11000148A3 /* PermanentDiskStorage.swift in Sources */,
 				BDEDD3661DBCE5D8007416A6 /* JSON.swift in Sources */,
 				BDEDD3711DBCE5D8007416A6 /* StorageAware.swift in Sources */,
 				BDEDD3681DBCE5D8007416A6 /* JSON+Cache.swift in Sources */,
@@ -930,6 +936,7 @@
 				D5ACACCA1CD01F3400567809 /* SyncCache.swift in Sources */,
 				D5291D8B1C283CFB00B702C9 /* Expiry.swift in Sources */,
 				D5ACACDF1CD0272600567809 /* Cache.swift in Sources */,
+				64A161071E871A10000148A3 /* PermanentDiskStorage.swift in Sources */,
 				D5291D891C283CFB00B702C9 /* Cachable.swift in Sources */,
 				D5291D961C283CFB00B702C9 /* StorageFactory.swift in Sources */,
 				D5291D7E1C283BF200B702C9 /* HybridCache.swift in Sources */,
@@ -968,6 +975,7 @@
 				D5ACACC91CD01F3400567809 /* SyncCache.swift in Sources */,
 				D5291C361C28220B00B702C9 /* String+Cache.swift in Sources */,
 				D5ACACDE1CD0272600567809 /* Cache.swift in Sources */,
+				64A161061E871A08000148A3 /* PermanentDiskStorage.swift in Sources */,
 				D5291C341C28220B00B702C9 /* NSData+Cache.swift in Sources */,
 				D5291C3A1C28220B00B702C9 /* StorageAware.swift in Sources */,
 				D5291C381C28220B00B702C9 /* DiskStorage.swift in Sources */,

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "krzyzanowskim/CryptoSwift" "0.6.8"
-github "Quick/Nimble" "v6.0.1"
+github "Quick/Nimble" "v6.1.0"
 github "Quick/Quick" "v1.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "krzyzanowskim/CryptoSwift" "0.6.1"
-github "Quick/Nimble" "v5.1.0"
-github "Quick/Quick" "v0.10.0"
+github "krzyzanowskim/CryptoSwift" "0.6.8"
+github "Quick/Nimble" "v6.0.1"
+github "Quick/Quick" "v1.1.0"

--- a/Source/Shared/Cache.swift
+++ b/Source/Shared/Cache.swift
@@ -29,7 +29,7 @@ public final class Cache<T: Cachable>: HybridCache {
    - Parameter expiry: Expiration date for the cached object
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public override func add(_ key: String, object: T, expiry: Expiry? = nil, completion: (() -> Void)? = nil) {
+  public func add(_ key: String, object: T, expiry: Expiry? = nil, completion: (() -> Void)? = nil) {
     super.add(key, object: object, expiry: expiry, completion: completion)
   }
 
@@ -39,7 +39,7 @@ public final class Cache<T: Cachable>: HybridCache {
    - Parameter key: Unique key to identify the object in the cache
    - Parameter completion: Completion closure returns object or nil
    */
-  public override func object(_ key: String, completion: @escaping (_ object: T?) -> Void) {
+  public func object(_ key: String, completion: @escaping (_ object: T?) -> Void) {
     super.object(key, completion: completion)
   }
 }

--- a/Source/Shared/DataStructures/StorageKind.swift
+++ b/Source/Shared/DataStructures/StorageKind.swift
@@ -6,6 +6,8 @@ public enum StorageKind {
   case memory
   /// Disk storage
   case disk
+  /// Permanent disk storage
+  case permanentDisk
   /// Custom kind of storage by the given name
   case custom(String)
 
@@ -18,6 +20,8 @@ public enum StorageKind {
       result = "Memory"
     case .disk:
       result = "Disk"
+    case .permanentDisk:
+        result = "permanentDisk"
     case .custom(let name):
       result = name
     }

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -4,7 +4,7 @@ import CryptoSwift
 /**
  File-based cache storage
  */
-public final class DiskStorage: StorageAware {
+public class DiskStorage: StorageAware {
 
   /// Domain prefix
   public static let prefix = "no.hyper.Cache.Disk"
@@ -31,19 +31,27 @@ public final class DiskStorage: StorageAware {
 
    - Parameter name: A name of the storage
    - Parameter maxSize: Maximum size of the cache storage
-   */
-  public required init(name: String, maxSize: UInt = 0) {
-    self.maxSize = maxSize
-    let cacheName = name.capitalized
-    let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
-      FileManager.SearchPathDomainMask.userDomainMask, true)
-
-    path = "\(paths.first!)/\(DiskStorage.prefix).\(cacheName)"
-    writeQueue = DispatchQueue(label: "\(DiskStorage.prefix).\(cacheName).WriteQueue",
-      attributes: [])
-    readQueue = DispatchQueue(label: "\(DiskStorage.prefix).\(cacheName).ReadQueue",
-      attributes: [])
-  }
+     */
+    public convenience required init(name: String, maxSize: UInt = 0) {
+        let cacheName = name.capitalized
+        let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
+                                                        FileManager.SearchPathDomainMask.userDomainMask, true)
+        
+        let path = "\(paths.first!)/\(DiskStorage.prefix).\(cacheName)"
+        self.init(name: name, maxSize: maxSize, path: path)
+    }
+    
+    public init(name: String, maxSize: UInt = 0, path: String) {
+        self.maxSize = maxSize
+        let cacheName = name.capitalized
+        
+        self.path = path
+        writeQueue = DispatchQueue(label: "\(DiskStorage.prefix).\(cacheName).WriteQueue",
+            attributes: [])
+        readQueue = DispatchQueue(label: "\(DiskStorage.prefix).\(cacheName).ReadQueue",
+            attributes: [])
+    }
+    
 
   // MARK: - CacheAware
 

--- a/Source/Shared/Storage/PermanentDiskStorage.swift
+++ b/Source/Shared/Storage/PermanentDiskStorage.swift
@@ -1,0 +1,23 @@
+//
+//  PermanentDiskStorage.swift
+//  Cache
+//
+//  Created by Pantelis Zirinis on 25/03/2017.
+//  Copyright © 2017 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation
+
+public class PermanentDiskStorage: DiskStorage {
+    
+    public required init(name: String, maxSize: UInt = 0) {
+        
+        let cacheName = name.capitalized
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory,
+                                                        FileManager.SearchPathDomainMask.userDomainMask, true)
+        
+        let path = "\(paths.first!)/\(DiskStorage.prefix).\(cacheName)"
+        super.init(name: name, maxSize: maxSize, path: path)
+    }
+
+}

--- a/Source/Shared/Storage/StorageFactory.swift
+++ b/Source/Shared/Storage/StorageFactory.swift
@@ -9,7 +9,8 @@ public final class StorageFactory {
   /// Dictionary of default storages
   fileprivate static var defaultStorages: [String: StorageAware.Type] = [
     StorageKind.memory.name : MemoryStorage.self,
-    StorageKind.disk.name : DiskStorage.self
+    StorageKind.disk.name : DiskStorage.self,
+    StorageKind.permanentDisk.name: PermanentDiskStorage.self
   ]
 
   /// Dictionary of storages

--- a/Tests/iOS/Specs/DataStructures/StorageKindSpec.swift
+++ b/Tests/iOS/Specs/DataStructures/StorageKindSpec.swift
@@ -11,6 +11,7 @@ class StorageKindSpec: QuickSpec {
         it("returns the correct name for default values") {
           expect(StorageKind.memory.name).to(equal("Memory"))
           expect(StorageKind.disk.name).to(equal("Disk"))
+            expect(StorageKind.permanentDisk.name).to(equal("PermanentDisk"))
         }
 
         it("returns the correct name for custom values") {


### PR DESCRIPTION
The current version is using cache directory to store object to disk. Cache directory can be deleted from the system at any time.

I added another disk storage called .permanentDisk that uses the documents directory. Anything stored there is guaranteed that it will stay there.