### PR TITLE
Remove file protection key from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the app’s container. Follow [App Distribution Guide](https://developer.apple.c
 data protection on iOS, WatchKit Extension, tvOS.
 
 In addition to that you can use a method on `HybridCache` and `SpecializedCache`
-to set file protection level:
+to set file protection level (iOS only):
 
 ```swift
 try cache.setFileProtection(.complete)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the app’s container. Follow [App Distribution Guide](https://developer.apple.c
 data protection on iOS, WatchKit Extension, tvOS.
 
 In addition to that you can use a method on `HybridCache` and `SpecializedCache`
-to set file protection level (iOS only):
+to set file protection level (iOS and tvOS only):
 
 ```swift
 try cache.setFileProtection(.complete)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   * [SpecializedSyncCache](#specialized-sync-cache)
   * [HybridSyncCache](#hybrid-sync-cache)
   * [Expiry date](#expiry-date)
+  * [Enabling Data Protection](#enabling-data-protection)
   * [Cachable protocol](#cachable-protocol)
 * [Optional bonuses](#optional-bonuses)
   * [JSON](#json)
@@ -88,9 +89,7 @@ let config = Config(
   // Where to store the disk cache. If nil, it is placed in an automatically generated directory in Caches
   cacheDirectory: NSSearchPathForDirectoriesInDomains(.documentDirectory,
                                                       FileManager.SearchPathDomainMask.userDomainMask,
-                                                      true).first! + "/cache-in-documents",
-  // Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
-  fileProtectionType: .complete
+                                                      true).first! + "/cache-in-documents"
 )
 
 let cache = HybridCache(name: "Custom", config: config)
@@ -212,6 +211,25 @@ cache.add("string", object: "This is a string",
 
 // Clear expired objects
 cache.clearExpired()
+```
+
+### Enabling data protection
+
+Data protection adds a level of security to files stored on disk by your app in
+the app’s container. Follow [App Distribution Guide](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW30) to enable
+data protection on iOS, WatchKit Extension, tvOS.
+
+In addition to that you can use a method on `HybridCache` and `SpecializedCache`
+to set file protection level:
+
+```swift
+try cache.setFileProtection(.complete)
+```
+
+It's also possible to update attributes of the disk cache folder:
+
+```swift
+try cache.setDirectoryAttributes([FileAttributeKey.immutable: true])
 ```
 
 ### Cachable protocol

--- a/Source/Shared/BasicHybridCache.swift
+++ b/Source/Shared/BasicHybridCache.swift
@@ -248,7 +248,7 @@ public class BasicHybridCache: NSObject {
 }
 
 extension BasicHybridCache {
-  #if os(iOS)
+  #if os(iOS) || os(tvOS)
   /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
   func setFileProtection( _ type: FileProtectionType) throws {
     try backStorage.setFileProtection(type)

--- a/Source/Shared/BasicHybridCache.swift
+++ b/Source/Shared/BasicHybridCache.swift
@@ -34,8 +34,7 @@ public class BasicHybridCache: NSObject {
     let backStorage = DiskStorage(
       name: name,
       maxSize: config.maxDiskSize,
-      cacheDirectory: config.cacheDirectory,
-      fileProtectionType: config.fileProtectionType
+      cacheDirectory: config.cacheDirectory
     )
     self.init(name: name, frontStorage: frontStorage, backStorage: backStorage, config: config)
   }
@@ -246,4 +245,18 @@ public class BasicHybridCache: NSObject {
   }
 
   #endif
+}
+
+extension BasicHybridCache {
+  #if os(iOS)
+  /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
+  func setFileProtection( _ type: FileProtectionType) throws {
+    try backStorage.setFileProtection(type)
+  }
+  #endif
+
+  /// Set attributes on the disk cache folder.
+  func setDiskCacheDirectoryAttributes(_ attributes: [FileAttributeKey : Any]) throws {
+    try backStorage.setDirectoryAttributes(attributes)
+  }
 }

--- a/Source/Shared/Config.swift
+++ b/Source/Shared/Config.swift
@@ -13,28 +13,23 @@ public struct Config {
   public let maxDiskSize: UInt
   /// A folder to store the disk cache contents. Defaults to a prefixed directory in Caches if nil
   public let cacheDirectory: String?
-  /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand.
-  public let fileProtectionType: FileProtectionType
 
   // MARK: - Initialization
 
   /**
    Creates a new instance of Config.
-   - Parameter frontKind: Front cache type
-   - Parameter backKind: Back cache type
    - Parameter expiry: Expiry date that will be applied by default for every added object
-   - Parameter maxSize: Maximum size of the cache storage
-   - Parameter maxObjects: Maximum amount of objects to be stored in memory
+   - Parameter maxObjectsInMemory: Maximum amount of items to store in memory
+   - Parameter maxDiskSize: Maximum size of the disk cache storage (in bytes)
+   - Parameter cacheDirectory: A folder to store the disk cache contents (Caches is default)
    */
   public init(expiry: Expiry = .never,
               maxObjectsInMemory: Int = 0,
               maxDiskSize: UInt = 0,
-              cacheDirectory: String? = nil,
-              fileProtectionType: FileProtectionType = .none) {
+              cacheDirectory: String? = nil) {
     self.expiry = expiry
     self.maxObjectsInMemory = maxObjectsInMemory
     self.maxDiskSize = maxDiskSize
     self.cacheDirectory = cacheDirectory
-    self.fileProtectionType = fileProtectionType
   }
 }

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -315,7 +315,7 @@ public final class DiskStorage: StorageAware {
 }
 
 extension DiskStorage {
-  #if os(iOS)
+  #if os(iOS) || os(tvOS)
   /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
   func setFileProtection( _ type: FileProtectionType) throws {
     try setDirectoryAttributes([FileAttributeKey.protectionKey: type])

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -15,10 +15,8 @@ public final class DiskStorage: StorageAware {
   public private(set) var writeQueue: DispatchQueue
   /// Queue for read operations
   public private(set) var readQueue: DispatchQueue
-  /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
-  private let fileProtectionType: FileProtectionType
   /// File manager to read/write to the disk
-  private let fileManager = FileManager()
+  fileprivate let fileManager = FileManager()
 
   // MARK: - Initialization
 
@@ -29,11 +27,8 @@ public final class DiskStorage: StorageAware {
    - Parameter cacheDirectory: (optional) A folder to store the disk cache contents. Defaults to a prefixed directory in Caches
    - Parameter fileProtectionType: Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
    */
-  public required init(name: String, maxSize: UInt = 0, cacheDirectory: String? = nil,
-                       fileProtectionType: FileProtectionType = .none) {
+  public required init(name: String, maxSize: UInt = 0, cacheDirectory: String? = nil) {
     self.maxSize = maxSize
-    self.fileProtectionType = fileProtectionType
-
     let fullName = [DiskStorage.prefix, name.capitalized].joined(separator: ".")
 
     if let cacheDirectory = cacheDirectory {
@@ -81,8 +76,7 @@ public final class DiskStorage: StorageAware {
           contents: object.encode() as Data?, attributes: nil)
         try weakSelf.fileManager.setAttributes(
           [
-            FileAttributeKey.modificationDate: expiry.date,
-            FileAttributeKey.protectionKey: weakSelf.fileProtectionType
+            FileAttributeKey.modificationDate: expiry.date
           ],
           ofItemAtPath: filePath)
       } catch {}
@@ -317,6 +311,20 @@ public final class DiskStorage: StorageAware {
    */
   func filePath(_ key: String) -> String {
     return "\(path)/\(fileName(key))"
+  }
+}
+
+extension DiskStorage {
+  #if os(iOS)
+  /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
+  func setFileProtection( _ type: FileProtectionType) throws {
+    try setDirectoryAttributes([FileAttributeKey.protectionKey: type])
+  }
+  #endif
+
+  /// Set attributes on the disk cache folder.
+  func setDirectoryAttributes(_ attributes: [FileAttributeKey : Any]) throws {
+    try fileManager.setAttributes(attributes, ofItemAtPath: path)
   }
 }
 

--- a/Tests/Mac/Helpers/NSImage+CacheTests.swift
+++ b/Tests/Mac/Helpers/NSImage+CacheTests.swift
@@ -2,15 +2,13 @@ import Cocoa
 @testable import Cache
 
 extension NSImage {
-
   func isEqualToImage(image: NSImage) -> Bool {
     return data == image.data
   }
 
   var data: Data {
     let representation = tiffRepresentation!
-
-    let imageFileType: NSBitmapImageFileType = hasAlpha ? .PNG : .JPEG
+    let imageFileType: NSBitmapImageFileType = .PNG
 
     return (NSBitmapImageRep(data: representation)?.representation(
       using: imageFileType,

--- a/Tests/Mac/Specs/Extensions/NSImage+CacheSpec.swift
+++ b/Tests/Mac/Specs/Extensions/NSImage+CacheSpec.swift
@@ -23,7 +23,7 @@ class NSImageCacheSpec: QuickSpec {
             let image = SpecHelper.image()
             let representation = image.tiffRepresentation!
 
-            let imageFileType: NSBitmapImageFileType = image.hasAlpha ? .PNG : .JPEG
+            let imageFileType: NSBitmapImageFileType = .PNG
             let data = NSBitmapImageRep(data: representation)!.representation(
               using: imageFileType, properties: [:])
 

--- a/Tests/iOS/Specs/SpecializedCacheSpec.swift
+++ b/Tests/iOS/Specs/SpecializedCacheSpec.swift
@@ -28,7 +28,6 @@ class SpecializedCacheSpec: QuickSpec {
           let defaultConfig = Config()
           expect(cache.config.expiry.date).to(equal(defaultConfig.expiry.date))
           expect(cache.config.cacheDirectory).to(beNil())
-          expect(cache.config.fileProtectionType).to(equal(defaultConfig.fileProtectionType))
           expect(cache.config.maxDiskSize).to(equal(defaultConfig.maxDiskSize))
           expect(cache.config.maxObjectsInMemory).to(equal(defaultConfig.maxObjectsInMemory))
           /**

--- a/Tests/iOS/Specs/Storage/DiskStorageSpec.swift
+++ b/Tests/iOS/Specs/Storage/DiskStorageSpec.swift
@@ -34,6 +34,24 @@ class DiskStorageSpec: QuickSpec {
             expect(storage.path).to(equal(path))
           }
         }
+
+        describe("#setDirectoryAttributes") {
+          it("sets attributes") {
+            let storage = DiskStorage(name: name)
+            let expectation = self.expectation(description: "Create Cache Directory Expectation")
+
+            storage.add(key, object: object) {
+              try! storage.setDirectoryAttributes([FileAttributeKey.immutable: true])
+              var attributes = try! fileManager.attributesOfItem(atPath: storage.path)
+              expect(attributes[FileAttributeKey.immutable] as? Bool).to(beTrue())
+
+              try! storage.setDirectoryAttributes([FileAttributeKey.immutable: false])
+              expectation.fulfill()
+            }
+
+            self.waitForExpectations(timeout: 2.0, handler:nil)
+          }
+        }
         
         describe("#maxSize") {
           it("returns the default maximum size of a cache") {
@@ -80,7 +98,7 @@ class DiskStorageSpec: QuickSpec {
           }
           
           it("returns entry if object exists") {
-            let storage = DiskStorage(name: name, fileProtectionType: .none)
+            let storage = DiskStorage(name: name)
             
             waitUntil(timeout: 2.0) { done in
               storage.add(key, object: object) {


### PR DESCRIPTION
I came into conclusion that it's no necessary to have `fileProtectionType` in `Config`. It's easier to set attributes to cache directory instead. It gives developer more freedom to update attributes when it's needed. In addition to `setDiskCacheDirectoryAttributes` there is also `setFileProtection` method for setting file protection directly, which is available on iOS only due to `FileProtectionType` availability on macOS (10.12+). Also it seems enough to enable data protection in `Capabilities`, so there is no need to set file protection level https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW30