### PR TITLE
Refactor sync/async Cache API

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -109,6 +109,9 @@
 		D5CE96931EE69969002BFE06 /* BasicHybridCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE968C1EE69969002BFE06 /* BasicHybridCache.swift */; };
 		D5CE96941EE69969002BFE06 /* BasicHybridCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE968C1EE69969002BFE06 /* BasicHybridCache.swift */; };
 		D5CE96951EE69969002BFE06 /* BasicHybridCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE968C1EE69969002BFE06 /* BasicHybridCache.swift */; };
+		D5FAF3891EE6F956000A71A8 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FAF3881EE6F956000A71A8 /* CacheManager.swift */; };
+		D5FAF38A1EE6F956000A71A8 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FAF3881EE6F956000A71A8 /* CacheManager.swift */; };
+		D5FAF38B1EE6F956000A71A8 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FAF3881EE6F956000A71A8 /* CacheManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -187,6 +190,7 @@
 		D5CE968B1EE69969002BFE06 /* HybridCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HybridCache.swift; sourceTree = "<group>"; };
 		D5CE968C1EE69969002BFE06 /* BasicHybridCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicHybridCache.swift; sourceTree = "<group>"; };
 		D5DC59E01C20593E003BD79B /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5FAF3881EE6F956000A71A8 /* CacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -440,9 +444,10 @@
 		D5CE96891EE69950002BFE06 /* Cache */ = {
 			isa = PBXGroup;
 			children = (
-				D5CE968A1EE69969002BFE06 /* SpecializedCache.swift */,
-				D5CE968B1EE69969002BFE06 /* HybridCache.swift */,
 				D5CE968C1EE69969002BFE06 /* BasicHybridCache.swift */,
+				D5FAF3881EE6F956000A71A8 /* CacheManager.swift */,
+				D5CE968B1EE69969002BFE06 /* HybridCache.swift */,
+				D5CE968A1EE69969002BFE06 /* SpecializedCache.swift */,
 			);
 			path = Cache;
 			sourceTree = "<group>";
@@ -831,6 +836,7 @@
 				D5CE966F1EE475C0002BFE06 /* Coding.swift in Sources */,
 				BDEDD36B1DBCE5D8007416A6 /* String+Cache.swift in Sources */,
 				BDEDD36A1DBCE5D8007416A6 /* Date+Cache.swift in Sources */,
+				D5FAF38B1EE6F956000A71A8 /* CacheManager.swift in Sources */,
 				BDEDD36F1DBCE5D8007416A6 /* DiskStorage.swift in Sources */,
 				57506FC01EC2E1BA009B71E9 /* CacheEntry.swift in Sources */,
 				D5A138C21EB29BFA00881A20 /* UIImage+Cache.swift in Sources */,
@@ -906,6 +912,7 @@
 				D5291D881C283CFB00B702C9 /* Config.swift in Sources */,
 				D5291D951C283CFB00B702C9 /* StorageAware.swift in Sources */,
 				D5291D911C283CFB00B702C9 /* String+Cache.swift in Sources */,
+				D5FAF38A1EE6F956000A71A8 /* CacheManager.swift in Sources */,
 				D5291D901C283CFB00B702C9 /* Date+Cache.swift in Sources */,
 				D5A138C41EB29C2100881A20 /* NSImage+Cache.swift in Sources */,
 				57506FBF1EC2E1B7009B71E9 /* CacheEntry.swift in Sources */,
@@ -945,6 +952,7 @@
 				D5291C351C28220B00B702C9 /* Date+Cache.swift in Sources */,
 				D5291C371C28220B00B702C9 /* DefaultCacheConverter.swift in Sources */,
 				D5291C301C28220B00B702C9 /* Expiry.swift in Sources */,
+				D5FAF3891EE6F956000A71A8 /* CacheManager.swift in Sources */,
 				D5291C331C28220B00B702C9 /* JSON+Cache.swift in Sources */,
 				57506FAE1EC29437009B71E9 /* CacheEntry.swift in Sources */,
 				D5A138C11EB29BFA00881A20 /* UIImage+Cache.swift in Sources */,

--- a/Source/Shared/Cache/BasicHybridCache.swift
+++ b/Source/Shared/Cache/BasicHybridCache.swift
@@ -8,29 +8,18 @@
  BasicHybridCache supports storing all kinds of objects, as long as they conform to
  Cachable protocol. It's two layered cache (with front and back storages)
  */
-public class BasicHybridCache: NSObject {
-  enum CacheError: Error {
-    case deallocated
-    case notFound
-  }
+public class BasicHybridCache {
   /// Domain prefix
   static let prefix = "no.hyper.Cache"
   /// A name of the cache
   public let name: String
-  /// Cache configuration
-  let config: Config
-  /// Memory cache
-  let frontStorage: MemoryStorage
-  // Disk cache (used for content that outlives the application life-cycle)
-  var backStorage: DiskStorage
-  /// Queue for write operations
-  private(set) var writeQueue: DispatchQueue
-  /// Queue for read operations
-  private(set) var readQueue: DispatchQueue
   // Disk storage path
   public var path: String {
-    return backStorage.path
+    return manager.backStorage.path
   }
+
+  /// Cache manager
+  let manager: CacheManager
 
   // MARK: - Inititalization
 
@@ -39,128 +28,9 @@ public class BasicHybridCache: NSObject {
    - Parameter name: A name of the cache
    - Parameter config: Cache configuration
    */
-  public convenience init(name: String, config: Config = Config()) {
-    let name = name
-    let frontStorage = MemoryStorage(
-      name: name,
-      countLimit: config.memoryCountLimit,
-      totalCostLimit: config.memoryTotalCostLimit
-    )
-    let backStorage = DiskStorage(
-      name: name,
-      maxSize: config.maxDiskSize,
-      cacheDirectory: config.cacheDirectory
-    )
-    self.init(name: name, frontStorage: frontStorage, backStorage: backStorage, config: config)
-  }
-
-  /**
-   Creates a new instance of BasicHybridCache.
-   - Parameter name: A name of the cache
-   - Parameter frontStorage: Memory cache instance
-   - Parameter backStorage: Disk cache instance
-   - Parameter config: Cache configuration
-   */
-  init(name: String, frontStorage: MemoryStorage, backStorage: DiskStorage, config: Config) {
+  public init(name: String, config: Config = Config()) {
     self.name = name
-    self.frontStorage = frontStorage
-    self.backStorage = backStorage
-    self.config = config
-
-    let queuePrefix = [BasicHybridCache.prefix, name].joined(separator: ".")
-    writeQueue = DispatchQueue(label: "\(queuePrefix).WriteQueue", attributes: [])
-    readQueue = DispatchQueue(label: "\(queuePrefix).ReadQueue", attributes: [])
-
-    super.init()
-    let notificationCenter = NotificationCenter.default
-
-    #if os(macOS)
-      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
-                                     name: NSNotification.Name.NSApplicationWillTerminate, object: nil)
-      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
-                                     name: NSNotification.Name.NSApplicationDidResignActive, object: nil)
-    #else
-      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInFrontStorage),
-                                     name: .UIApplicationDidReceiveMemoryWarning, object: nil)
-      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
-                                     name: .UIApplicationWillTerminate, object: nil)
-      notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationDidEnterBackground),
-                                     name: .UIApplicationDidEnterBackground, object: nil)
-    #endif
-  }
-
-  /**
-   Removes notification center observer.
-   */
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
-  #if !os(macOS)
-
-  /**
-   Clears expired cache items when the app enters background.
-   */
-  @objc private func applicationDidEnterBackground() {
-    let application = UIApplication.shared
-    var backgroundTask: UIBackgroundTaskIdentifier?
-
-    backgroundTask = application.beginBackgroundTask (expirationHandler: { [weak self] in
-      guard let backgroundTask = backgroundTask else {
-        return
-      }
-      var mutableBackgroundTask = backgroundTask
-      self?.endBackgroundTask(&mutableBackgroundTask)
-    })
-
-    writeQueue.async { [weak self] in
-      guard let `self` = self, let backgroundTask = backgroundTask else {
-        return
-      }
-      do {
-        try self.backStorage.clearExpired()
-      } catch {
-        Logger.log(error: error)
-      }
-      var mutableBackgroundTask = backgroundTask
-
-      DispatchQueue.main.async { [weak self] in
-        self?.endBackgroundTask(&mutableBackgroundTask)
-      }
-    }
-  }
-
-  /**
-   Ends given background task.
-   - Parameter task: A UIBackgroundTaskIdentifier
-   */
-  private func endBackgroundTask(_ task: inout UIBackgroundTaskIdentifier) {
-    UIApplication.shared.endBackgroundTask(task)
-    task = UIBackgroundTaskInvalid
-  }
-
-  #endif
-
-  /**
-   Clears expired cache items in front cache.
-   */
-  @objc private func clearExpiredDataInFrontStorage() {
-    writeQueue.async { [weak self] in
-      self?.frontStorage.clearExpired()
-    }
-  }
-
-  /**
-   Clears expired cache items in back cache.
-   */
-  @objc private func clearExpiredDataInBackStorage() {
-    writeQueue.async { [weak self] in
-      do {
-        try self?.backStorage.clearExpired()
-      } catch {
-        Logger.log(error: error)
-      }
-    }
+    self.manager = CacheManager(name: name, config: config)
   }
 }
 
@@ -170,140 +40,12 @@ public extension BasicHybridCache {
   #if os(iOS) || os(tvOS)
   /// Data protection is used to store files in an encrypted format on disk and to decrypt them on demand
   func setFileProtection( _ type: FileProtectionType) throws {
-    try backStorage.setFileProtection(type)
+    try manager.backStorage.setFileProtection(type)
   }
   #endif
 
   /// Set attributes on the disk cache folder.
   func setDiskCacheDirectoryAttributes(_ attributes: [FileAttributeKey : Any]) throws {
-    try backStorage.setDirectoryAttributes(attributes)
-  }
-}
-
-// MARK: - Async caching
-
-extension BasicHybridCache {
-  public typealias Completion = (Error?) -> Void
-  /**
-   Adds passed object to the front and back cache storages.
-   - Parameter object: Object that needs to be cached
-   - Parameter key: Unique key to identify the object in the cache
-   - Parameter expiry: Expiration date for the cached object
-   - Parameter completion: Completion closure to be called when the task is done
-   */
-  func add<T: Cachable>(_ object: T, forKey key: String, expiry: Expiry?, completion: Completion? = nil) {
-    let expiry = expiry ?? config.expiry
-    writeQueue.async { [weak self] in
-      do {
-        guard let `self` = self else {
-          throw CacheError.deallocated
-        }
-        self.frontStorage.add(key, object: object, expiry: expiry)
-        try self.backStorage.add(key, object: object, expiry: expiry)
-        completion?(nil)
-      } catch {
-        Logger.log(error: error)
-        completion?(error)
-      }
-    }
-  }
-
-  /**
-   Tries to retrieve the object from to the front and back cache storages.
-   - Parameter key: Unique key to identify the object in the cache
-   - Parameter completion: Completion closure to be called when the task is done
-   */
-  func object<T: Cachable>(forKey key: String, completion: @escaping (T?) -> Void) {
-    cacheEntry(forKey: key) { (entry: CacheEntry<T>?) in
-      completion(entry?.object)
-    }
-  }
-
-  /**
-   Tries to retrieve the cache entry from to the front and back cache storages.
-   - Parameter key: Unique key to identify the cache entry in the cache
-   - Parameter completion: Completion closure to be called when the task is done
-   */
-  func cacheEntry<T: Cachable>(forKey key: String, completion: @escaping (CacheEntry<T>?) -> Void) {
-    readQueue.async { [weak self] in
-      do {
-        guard let `self` = self else {
-          throw CacheError.notFound
-        }
-        if let entry: CacheEntry<T> = self.frontStorage.cacheEntry(key) {
-          completion(entry)
-          return
-        }
-        guard let entry: CacheEntry<T> = try self.backStorage.cacheEntry(key) else {
-          throw CacheError.notFound
-        }
-        self.frontStorage.add(key, object: entry.object, expiry: entry.expiry)
-        completion(entry)
-      } catch {
-        Logger.log(error: error)
-        completion(nil)
-      }
-    }
-  }
-
-  /**
-   Removes the object from to the front and back cache storages.
-   - Parameter key: Unique key to identify the object in the cache
-   - Parameter completion: Completion closure to be called when the task is done
-   */
-  public func remove(_ key: String, completion: Completion? = nil) {
-    writeQueue.async { [weak self] in
-      do {
-        guard let `self` = self else {
-          throw CacheError.deallocated
-        }
-        self.frontStorage.remove(key)
-        try self.backStorage.remove(key)
-        completion?(nil)
-      } catch {
-        Logger.log(error: error)
-        completion?(error)
-      }
-    }
-  }
-
-  /**
-   Clears the front and back cache storages.
-   - Parameter completion: Completion closure to be called when the task is done
-   */
-  public func clear(completion: Completion? = nil) {
-    writeQueue.async { [weak self] in
-      do {
-        guard let `self` = self else {
-          throw CacheError.deallocated
-        }
-        self.frontStorage.clear()
-        try self.backStorage.clear()
-        completion?(nil)
-      } catch {
-        Logger.log(error: error)
-        completion?(error)
-      }
-    }
-  }
-
-  /**
-   Clears all expired objects from front and back storages.
-   - Parameter completion: Completion closure to be called when the task is done
-   */
-  public func clearExpired(completion: Completion? = nil) {
-    writeQueue.async { [weak self] in
-      do {
-        guard let `self` = self else {
-          throw CacheError.deallocated
-        }
-        self.frontStorage.clearExpired()
-        try self.backStorage.clearExpired()
-        completion?(nil)
-      } catch {
-        Logger.log(error: error)
-        completion?(error)
-      }
-    }
+    try manager.backStorage.setDirectoryAttributes(attributes)
   }
 }

--- a/Source/Shared/Cache/CacheManager.swift
+++ b/Source/Shared/Cache/CacheManager.swift
@@ -1,0 +1,370 @@
+#if os(macOS)
+  import AppKit
+#else
+  import UIKit
+#endif
+
+// Completion with error
+public typealias Completion = (Error?) -> Void
+
+/**
+ BasicHybridCache supports storing all kinds of objects, as long as they conform to
+ Cachable protocol. It's two layered cache (with front and back storages)
+ */
+class CacheManager: NSObject {
+  enum CacheError: Error {
+    case deallocated
+    case notFound
+  }
+  /// Domain prefix
+  static let prefix = "no.hyper.Cache"
+  /// Cache configuration
+  let config: Config
+  /// Memory cache
+  let frontStorage: MemoryStorage
+  // Disk cache (used for content that outlives the application life-cycle)
+  var backStorage: DiskStorage
+  /// Queue for write operations
+  fileprivate let writeQueue: DispatchQueue
+  /// Queue for read operations
+  fileprivate let readQueue: DispatchQueue
+
+  // MARK: - Inititalization
+
+  /**
+   Creates a new instance of BasicHybridCache.
+   - Parameter name: A name of the cache
+   - Parameter config: Cache configuration
+   */
+  convenience init(name: String, config: Config = Config()) {
+    let name = name
+    let frontStorage = MemoryStorage(
+      name: name,
+      countLimit: config.memoryCountLimit,
+      totalCostLimit: config.memoryTotalCostLimit
+    )
+    let backStorage = DiskStorage(
+      name: name,
+      maxSize: config.maxDiskSize,
+      cacheDirectory: config.cacheDirectory
+    )
+    self.init(name: name, frontStorage: frontStorage, backStorage: backStorage, config: config)
+  }
+
+  /**
+   Creates a new instance of BasicHybridCache.
+   - Parameter name: A name of the cache
+   - Parameter frontStorage: Memory cache instance
+   - Parameter backStorage: Disk cache instance
+   - Parameter config: Cache configuration
+   */
+  private init(name: String, frontStorage: MemoryStorage, backStorage: DiskStorage, config: Config) {
+    self.frontStorage = frontStorage
+    self.backStorage = backStorage
+    self.config = config
+
+    let queuePrefix = [BasicHybridCache.prefix, name].joined(separator: ".")
+    writeQueue = DispatchQueue(label: "\(queuePrefix).WriteQueue", attributes: [])
+    readQueue = DispatchQueue(label: "\(queuePrefix).ReadQueue", attributes: [])
+
+    super.init()
+    let notificationCenter = NotificationCenter.default
+
+    #if os(macOS)
+      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
+                                     name: NSNotification.Name.NSApplicationWillTerminate, object: nil)
+      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
+                                     name: NSNotification.Name.NSApplicationDidResignActive, object: nil)
+    #else
+      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInFrontStorage),
+                                     name: .UIApplicationDidReceiveMemoryWarning, object: nil)
+      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
+                                     name: .UIApplicationWillTerminate, object: nil)
+      notificationCenter.addObserver(self, selector: #selector(CacheManager.applicationDidEnterBackground),
+                                     name: .UIApplicationDidEnterBackground, object: nil)
+    #endif
+  }
+
+  /**
+   Removes notification center observer.
+   */
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  #if !os(macOS)
+
+  /**
+   Clears expired cache items when the app enters background.
+   */
+  @objc private func applicationDidEnterBackground() {
+    let application = UIApplication.shared
+    var backgroundTask: UIBackgroundTaskIdentifier?
+
+    backgroundTask = application.beginBackgroundTask (expirationHandler: { [weak self] in
+      guard let backgroundTask = backgroundTask else {
+        return
+      }
+      var mutableBackgroundTask = backgroundTask
+      self?.endBackgroundTask(&mutableBackgroundTask)
+    })
+
+    writeQueue.async { [weak self] in
+      guard let `self` = self, let backgroundTask = backgroundTask else {
+        return
+      }
+      do {
+        try self.backStorage.clearExpired()
+      } catch {
+        Logger.log(error: error)
+      }
+      var mutableBackgroundTask = backgroundTask
+
+      DispatchQueue.main.async { [weak self] in
+        self?.endBackgroundTask(&mutableBackgroundTask)
+      }
+    }
+  }
+
+  /**
+   Ends given background task.
+   - Parameter task: A UIBackgroundTaskIdentifier
+   */
+  private func endBackgroundTask(_ task: inout UIBackgroundTaskIdentifier) {
+    UIApplication.shared.endBackgroundTask(task)
+    task = UIBackgroundTaskInvalid
+  }
+
+  #endif
+
+  /**
+   Clears expired cache items in front cache.
+   */
+  @objc private func clearExpiredDataInFrontStorage() {
+    writeQueue.async { [weak self] in
+      self?.frontStorage.clearExpired()
+    }
+  }
+
+  /**
+   Clears expired cache items in back cache.
+   */
+  @objc private func clearExpiredDataInBackStorage() {
+    writeQueue.async { [weak self] in
+      do {
+        try self?.backStorage.clearExpired()
+      } catch {
+        Logger.log(error: error)
+      }
+    }
+  }
+}
+
+// MARK: - Async caching
+
+extension CacheManager {
+  /**
+   Adds passed object to the front and back cache storages.
+   - Parameter object: Object that needs to be cached
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter expiry: Expiration date for the cached object
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  func addObject<T: Cachable>(_ object: T, forKey key: String, expiry: Expiry?, completion: Completion?) {
+    let expiry = expiry ?? config.expiry
+    writeQueue.async { [weak self] in
+      do {
+        guard let `self` = self else {
+          throw CacheError.deallocated
+        }
+        self.frontStorage.add(key, object: object, expiry: expiry)
+        try self.backStorage.add(key, object: object, expiry: expiry)
+        completion?(nil)
+      } catch {
+        Logger.log(error: error)
+        completion?(error)
+      }
+    }
+  }
+
+  /**
+   Tries to retrieve the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  func object<T: Cachable>(forKey key: String, completion: @escaping (T?) -> Void) {
+    cacheEntry(forKey: key) { (entry: CacheEntry<T>?) in
+      completion(entry?.object)
+    }
+  }
+
+  /**
+   Tries to retrieve the cache entry from to the front and back cache storages.
+   - Parameter key: Unique key to identify the cache entry in the cache
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  func cacheEntry<T: Cachable>(forKey key: String, completion: @escaping (CacheEntry<T>?) -> Void) {
+    readQueue.async { [weak self] in
+      do {
+        guard let `self` = self else {
+          throw CacheError.notFound
+        }
+        if let entry: CacheEntry<T> = self.frontStorage.cacheEntry(key) {
+          completion(entry)
+          return
+        }
+        guard let entry: CacheEntry<T> = try self.backStorage.cacheEntry(key) else {
+          throw CacheError.notFound
+        }
+        self.frontStorage.add(key, object: entry.object, expiry: entry.expiry)
+        completion(entry)
+      } catch {
+        Logger.log(error: error)
+        completion(nil)
+      }
+    }
+  }
+
+  /**
+   Removes the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  func removeObject(forKey key: String, completion: Completion?) {
+    writeQueue.async { [weak self] in
+      do {
+        guard let `self` = self else {
+          throw CacheError.deallocated
+        }
+        self.frontStorage.remove(key)
+        try self.backStorage.remove(key)
+        completion?(nil)
+      } catch {
+        Logger.log(error: error)
+        completion?(error)
+      }
+    }
+  }
+
+  /**
+   Clears the front and back cache storages.
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  func clear(completion: Completion?) {
+    writeQueue.async { [weak self] in
+      do {
+        guard let `self` = self else {
+          throw CacheError.deallocated
+        }
+        self.frontStorage.clear()
+        try self.backStorage.clear()
+        completion?(nil)
+      } catch {
+        Logger.log(error: error)
+        completion?(error)
+      }
+    }
+  }
+
+  /**
+   Clears all expired objects from front and back storages.
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  func clearExpired(completion: Completion?) {
+    writeQueue.async { [weak self] in
+      do {
+        guard let `self` = self else {
+          throw CacheError.deallocated
+        }
+        self.frontStorage.clearExpired()
+        try self.backStorage.clearExpired()
+        completion?(nil)
+      } catch {
+        Logger.log(error: error)
+        completion?(error)
+      }
+    }
+  }
+}
+
+// MARK: - Sync caching
+
+extension CacheManager {
+  /**
+   Adds passed object to the front and back cache storages.
+   - Parameter object: Object that needs to be cached
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter expiry: Expiration date for the cached object
+   */
+  func addObject<T: Cachable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+    let expiry = expiry ?? config.expiry
+    try writeQueue.sync { [weak self] in
+      self?.frontStorage.add(key, object: object, expiry: expiry)
+      try self?.backStorage.add(key, object: object, expiry: expiry)
+    }
+  }
+
+  /**
+   Tries to retrieve the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Returns: Object from cache of nil
+   */
+  func object<T: Cachable>(forKey key: String) -> T? {
+    return (cacheEntry(forKey: key) as CacheEntry<T>?)?.object
+  }
+
+  /**
+   Tries to retrieve the cache entry from to the front and back cache storages.
+   - Parameter key: Unique key to identify the cache entry in the cache
+   - Returns: Object from cache of nil
+   */
+  func cacheEntry<T: Cachable>(forKey key: String) -> CacheEntry<T>? {
+    var result: CacheEntry<T>?
+    readQueue.sync { [weak self] in
+      do {
+        if let entry: CacheEntry<T> = self?.frontStorage.cacheEntry(key) {
+          result = entry
+          return
+        }
+        if let entry: CacheEntry<T> = try self?.backStorage.cacheEntry(key) {
+          self?.frontStorage.add(key, object: entry.object, expiry: entry.expiry)
+          result = entry
+        }
+      } catch {
+        Logger.log(error: error)
+      }
+    }
+    return result
+  }
+
+  /**
+   Removes the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   */
+  func removeObject(forKey key: String) throws {
+    try writeQueue.sync { [weak self] in
+      self?.frontStorage.remove(key)
+      try self?.backStorage.remove(key)
+    }
+  }
+
+  /**
+   Clears the front and back cache storages.
+   */
+  func clear() throws {
+    try writeQueue.sync { [weak self] in
+      self?.frontStorage.clear()
+      try self?.backStorage.clear()
+    }
+  }
+
+  /**
+   Clears all expired objects from front and back storages.
+   */
+  func clearExpired() throws {
+    try writeQueue.sync { [weak self] in
+      self?.frontStorage.clearExpired()
+      try self?.backStorage.clearExpired()
+    }
+  }
+}

--- a/Source/Shared/Cache/HybridCache.swift
+++ b/Source/Shared/Cache/HybridCache.swift
@@ -4,16 +4,83 @@
  Subscribes to system notifications to clear expired cached objects.
  */
 public class HybridCache: BasicHybridCache {
+  /// Async cache wrapper
+  public private(set) lazy var async: AcycnHybridCache = .init(manager: self.manager)
+
   /**
    Adds passed object to the front and back cache storages.
-   - Parameter key: Unique key to identify the object in the cache
    - Parameter object: Object that needs to be cached
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter expiry: Expiration date for the cached object
+   */
+  func addObject<T: Cachable>(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
+    try manager.addObject(object, forKey: key, expiry: expiry)
+  }
+
+  /**
+   Tries to retrieve the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Returns: Object from cache of nil
+   */
+  func object<T: Cachable>(forKey key: String) -> T? {
+    return manager.object(forKey: key)
+  }
+
+  /**
+   Tries to retrieve the cache entry from to the front and back cache storages.
+   - Parameter key: Unique key to identify the cache entry in the cache
+   - Returns: Object from cache of nil
+   */
+  func cacheEntry<T: Cachable>(forKey key: String) -> CacheEntry<T>? {
+    return manager.cacheEntry(forKey: key)
+  }
+
+  /**
+   Removes the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   */
+  func removeObject(forKey key: String) throws {
+    try manager.removeObject(forKey: key)
+  }
+
+  /**
+   Clears the front and back cache storages.
+   */
+  func clear() throws {
+    try manager.clear()
+  }
+
+  /**
+   Clears all expired objects from front and back storages.
+   */
+  func clearExpired() throws {
+    try manager.clearExpired()
+  }
+}
+
+/// Wrapper around async cache operations.
+public class AcycnHybridCache {
+  /// Cache manager
+  private let manager: CacheManager
+
+  /**
+   Creates a new instance of AcycnHybridCache.
+   - Parameter manager: Cache manager
+   */
+  init(manager: CacheManager) {
+    self.manager = manager
+  }
+
+  /**
+   Adds passed object to the front and back cache storages.
+   - Parameter object: Object that needs to be cached
+   - Parameter key: Unique key to identify the object in the cache
    - Parameter expiry: Expiration date for the cached object
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func add<T: Cachable>(_ key: String, object: T, expiry: Expiry? = nil,
-                  completion: Completion? = nil) {
-    return super.add(object, forKey: key, expiry: expiry, completion: completion)
+  public func addObject<T: Cachable>(_ object: T, forKey key: String, expiry: Expiry? = nil,
+                        completion: Completion?) {
+    manager.addObject(object, forKey: key, expiry: expiry, completion: completion)
   }
 
   /**
@@ -21,8 +88,8 @@ public class HybridCache: BasicHybridCache {
    - Parameter key: Unique key to identify the object in the cache
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func object<T: Cachable>(_ key: String, completion: @escaping (T?) -> Void) {
-    return super.object(forKey: key, completion: completion)
+  public func object<T: Cachable>(forKey key: String, completion: @escaping (T?) -> Void) {
+    manager.object(forKey: key, completion: completion)
   }
 
   /**
@@ -30,7 +97,32 @@ public class HybridCache: BasicHybridCache {
    - Parameter key: Unique key to identify the cache entry in the cache
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func cacheEntry<T: Cachable>(_ key: String, completion: @escaping (CacheEntry<T>?) -> Void) {
-    return super.cacheEntry(forKey: key, completion: completion)
+  public func cacheEntry<T: Cachable>(forKey key: String, completion: @escaping (CacheEntry<T>?) -> Void) {
+    manager.cacheEntry(forKey: key, completion: completion)
+  }
+
+  /**
+   Removes the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  public func removeObject(forKey key: String, completion: Completion?) {
+    manager.removeObject(forKey: key, completion: completion)
+  }
+
+  /**
+   Clears the front and back cache storages.
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  public func clear(completion: Completion?) {
+    manager.clear(completion: completion)
+  }
+
+  /**
+   Clears all expired objects from front and back storages.
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  public func clearExpired(completion: Completion?) {
+    manager.clearExpired(completion: completion)
   }
 }

--- a/Source/Shared/Cache/HybridCache.swift
+++ b/Source/Shared/Cache/HybridCache.swift
@@ -5,7 +5,7 @@
  */
 public class HybridCache: BasicHybridCache {
   /// Async cache wrapper
-  public private(set) lazy var async: AcycnHybridCache = .init(manager: self.manager)
+  public private(set) lazy var async: AsyncHybridCache = .init(manager: self.manager)
 
   /**
    Adds passed object to the front and back cache storages.
@@ -59,7 +59,7 @@ public class HybridCache: BasicHybridCache {
 }
 
 /// Wrapper around async cache operations.
-public class AcycnHybridCache {
+public class AsyncHybridCache {
   /// Cache manager
   private let manager: CacheManager
 

--- a/Source/Shared/Cache/SpecializedCache.swift
+++ b/Source/Shared/Cache/SpecializedCache.swift
@@ -6,15 +6,82 @@ import Foundation
  Subscribes to system notifications to clear expired cached objects.
  */
 public final class SpecializedCache<T: Cachable>: BasicHybridCache {
+  /// Async cache wrapper
+  public private(set) lazy var async: AcyncSpecializedCache<T> = .init(manager: self.manager)
+
   /**
    Adds passed object to the front and back cache storages.
-   - Parameter key: Unique key to identify the object in the cache
    - Parameter object: Object that needs to be cached
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter expiry: Expiration date for the cached object
+   */
+  func addObject(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
+    try manager.addObject(object, forKey: key, expiry: expiry)
+  }
+
+  /**
+   Tries to retrieve the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Returns: Object from cache of nil
+   */
+  func object(forKey key: String) -> T? {
+    return manager.object(forKey: key)
+  }
+
+  /**
+   Tries to retrieve the cache entry from to the front and back cache storages.
+   - Parameter key: Unique key to identify the cache entry in the cache
+   - Returns: Object from cache of nil
+   */
+  func cacheEntry(forKey key: String) -> CacheEntry<T>? {
+    return manager.cacheEntry(forKey: key)
+  }
+
+  /**
+   Removes the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   */
+  func removeObject(forKey key: String) throws {
+    try manager.removeObject(forKey: key)
+  }
+
+  /**
+   Clears the front and back cache storages.
+   */
+  func clear() throws {
+    try manager.clear()
+  }
+
+  /**
+   Clears all expired objects from front and back storages.
+   */
+  func clearExpired() throws {
+    try manager.clearExpired()
+  }
+}
+
+/// Wrapper around async cache operations.
+public class AcyncSpecializedCache<T: Cachable> {
+  /// Cache manager
+  private let manager: CacheManager
+
+  /**
+   Creates a new instance of AcycnHybridCache.
+   - Parameter manager: Cache manager
+   */
+  init(manager: CacheManager) {
+    self.manager = manager
+  }
+
+  /**
+   Adds passed object to the front and back cache storages.
+   - Parameter object: Object that needs to be cached
+   - Parameter key: Unique key to identify the object in the cache
    - Parameter expiry: Expiration date for the cached object
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func add(_ key: String, object: T, expiry: Expiry? = nil, completion: Completion? = nil) {
-    return super.add(object, forKey: key, expiry: expiry, completion: completion)
+  public func addObject(_ object: T, forKey key: String, expiry: Expiry? = nil, completion: Completion?) {
+    manager.addObject(object, forKey: key, expiry: expiry, completion: completion)
   }
 
   /**
@@ -22,8 +89,8 @@ public final class SpecializedCache<T: Cachable>: BasicHybridCache {
    - Parameter key: Unique key to identify the object in the cache
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func object(_ key: String, completion: @escaping (T?) -> Void) {
-    return super.object(forKey: key, completion: completion)
+  public func object(forKey key: String, completion: @escaping (T?) -> Void) {
+    manager.object(forKey: key, completion: completion)
   }
 
   /**
@@ -31,7 +98,32 @@ public final class SpecializedCache<T: Cachable>: BasicHybridCache {
    - Parameter key: Unique key to identify the cache entry in the cache
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func cacheEntry(_ key: String, completion: @escaping (CacheEntry<T>?) -> Void) {
-    return super.cacheEntry(forKey: key, completion: completion)
+  public func cacheEntry(forKey key: String, completion: @escaping (CacheEntry<T>?) -> Void) {
+    manager.cacheEntry(forKey: key, completion: completion)
+  }
+
+  /**
+   Removes the object from to the front and back cache storages.
+   - Parameter key: Unique key to identify the object in the cache
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  public func removeObject(forKey key: String, completion: Completion?) {
+    manager.removeObject(forKey: key, completion: completion)
+  }
+
+  /**
+   Clears the front and back cache storages.
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  public func clear(completion: Completion?) {
+    manager.clear(completion: completion)
+  }
+
+  /**
+   Clears all expired objects from front and back storages.
+   - Parameter completion: Completion closure to be called when the task is done
+   */
+  public func clearExpired(completion: Completion?) {
+    manager.clearExpired(completion: completion)
   }
 }

--- a/Source/Shared/Cache/SpecializedCache.swift
+++ b/Source/Shared/Cache/SpecializedCache.swift
@@ -7,7 +7,7 @@ import Foundation
  */
 public final class SpecializedCache<T: Cachable>: BasicHybridCache {
   /// Async cache wrapper
-  public private(set) lazy var async: AcyncSpecializedCache<T> = .init(manager: self.manager)
+  public private(set) lazy var async: AsyncSpecializedCache<T> = .init(manager: self.manager)
 
   /**
    Adds passed object to the front and back cache storages.
@@ -61,7 +61,7 @@ public final class SpecializedCache<T: Cachable>: BasicHybridCache {
 }
 
 /// Wrapper around async cache operations.
-public class AcyncSpecializedCache<T: Cachable> {
+public class AsyncSpecializedCache<T: Cachable> {
   /// Cache manager
   private let manager: CacheManager
 


### PR DESCRIPTION
`HybridCache` and `SpecializedCache` are now sync by default, but if you want to read/write async there is a new API specifically for that:

```swift
cache.async.addObject(object, forKey: key, expiry: .date(expiryDate)) { error in
}
cache.async.object(forKey: self.key) { object in
}
```

P.S. This PR is not supposed to be that big, here I basically move code around and refactor tests (and its apparently a lot of lines of code)