### PR TITLE
Use a set of keys to be able to remove expired items

### DIFF
--- a/Tests/iOS/Specs/Storage/MemoryStorageSpec.swift
+++ b/Tests/iOS/Specs/Storage/MemoryStorageSpec.swift
@@ -100,7 +100,7 @@ class MemoryStorageSpec: QuickSpec {
           let object2: User? = storage.object(key2)
 
           expect(object1).to(beNil())
-          expect(object2).to(beNil())
+          expect(object2).toNot(beNil())
         }
       }
     }


### PR DESCRIPTION
As it's not possible to iterate through `NSCache` keys we use a set of keys to workaround this problem.