### PR TITLE
Implement subscript in specialised cache

### DIFF
--- a/Source/Shared/Cache/SpecializedCache.swift
+++ b/Source/Shared/Cache/SpecializedCache.swift
@@ -10,6 +10,28 @@ public final class SpecializedCache<T: Cachable>: BasicHybridCache {
   public private(set) lazy var async: AsyncSpecializedCache<T> = .init(manager: self.manager)
 
   /**
+   Subscript wrapper around `object`, `addObject`, `removeObject` methods
+   - Parameter key: Unique key to identify the object in the cache
+   - Returns: Object from cache of nil
+   */
+  public subscript(key: String) -> T? {
+    get {
+      return object(forKey: key)
+    }
+    set(newValue) {
+      do {
+        if let value = newValue {
+          try addObject(value, forKey: key)
+        } else {
+          try removeObject(forKey: key)
+        }
+      } catch {
+        Logger.log(error: error)
+      }
+    }
+  }
+
+  /**
    Adds passed object to the front and back cache storages.
    - Parameter object: Object that needs to be cached
    - Parameter key: Unique key to identify the object in the cache

--- a/Tests/iOS/Specs/SpecializedCacheTests.swift
+++ b/Tests/iOS/Specs/SpecializedCacheTests.swift
@@ -223,6 +223,25 @@ final class SpecializedCacheTests: XCTestCase {
 
   // MARK: - Sync caching
 
+  func testSubscript() throws {
+    XCTAssertNil(cache[key])
+    // Add
+    cache[key] = object
+    XCTAssertNotNil(cache.manager.frontStorage.object(self.key) as User?)
+    XCTAssertNotNil(try cache.manager.backStorage.object(self.key) as User?)
+    // Get
+    XCTAssertNotNil(cache[key])
+    // Remove
+    cache[key] = nil
+    XCTAssertNil(cache[key])
+    XCTAssertNil(cache.manager.frontStorage.object(self.key) as User?)
+    var user: User?
+    do {
+       user = try cache.manager.backStorage.object(self.key)
+    } catch {}
+    XCTAssertNil(user)
+  }
+
   func testAdd() throws {
     try cache.addObject(object, forKey: key)
     let cachedObject = cache.object(forKey: key)
@@ -231,7 +250,7 @@ final class SpecializedCacheTests: XCTestCase {
     let memoryObject: User? = cache.manager.frontStorage.object(self.key)
     XCTAssertNotNil(memoryObject)
 
-    let diskObject: User? = try! cache.manager.backStorage.object(self.key)
+    let diskObject: User? = try cache.manager.backStorage.object(self.key)
     XCTAssertNotNil(diskObject)
   }
 


### PR DESCRIPTION
Add subscript wrapper around `object`, `addObject`, `removeObject` methods:

```swift
// Add
cache["key"] = object
// Get
print(cache["key"])
// Remove
cache["key"] = nil
```