### PR TITLE
Feature: clear keeping root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ let size = try cache.totalDiskSize()
 try cache.removeObject(forKey: "data")
 
 // Clear cache
-try cache.clear()
+// Pass `true` to keep the existing disk cache directory after removing
+// its contents. The default value for `keepingRootDirectory` is `false`.
+try cache.clear(keepingRootDirectory: true)
 
 // Clear expired objects
 try cache.clearExpired()

--- a/Source/Shared/Cache/CacheManager.swift
+++ b/Source/Shared/Cache/CacheManager.swift
@@ -251,9 +251,11 @@ extension CacheManager {
 
   /**
    Clears the front and back cache storages.
+   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   after removing its contents. The default value is `false`.
    - Parameter completion: Completion closure to be called when the task is done
    */
-  func clear(completion: Completion?) {
+  func clear(keepingDirectory: Bool = false, completion: Completion?) {
     writeQueue.async { [weak self] in
       do {
         guard let `self` = self else {
@@ -261,6 +263,9 @@ extension CacheManager {
         }
         self.frontStorage.clear()
         try self.backStorage.clear()
+        if keepingDirectory {
+          try self.backStorage.createDirectory()
+        }
         completion?(nil)
       } catch {
         Logger.log(error: error)
@@ -364,11 +369,16 @@ extension CacheManager {
 
   /**
    Clears the front and back cache storages.
+   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   after removing its contents. The default value is `false`.
    */
-  func clear() throws {
+  func clear(keepingDirectory: Bool = false) throws {
     try writeQueue.sync { [weak self] in
       self?.frontStorage.clear()
       try self?.backStorage.clear()
+      if keepingDirectory {
+        try self?.backStorage.createDirectory()
+      }
     }
   }
 

--- a/Source/Shared/Cache/CacheManager.swift
+++ b/Source/Shared/Cache/CacheManager.swift
@@ -251,11 +251,11 @@ extension CacheManager {
 
   /**
    Clears the front and back cache storages.
-   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   - Parameter keepingRootDirectory: Pass `true` to keep the existing disk cache directory
    after removing its contents. The default value is `false`.
    - Parameter completion: Completion closure to be called when the task is done
    */
-  func clear(keepingDirectory: Bool = false, completion: Completion?) {
+  func clear(keepingRootDirectory: Bool = false, completion: Completion?) {
     writeQueue.async { [weak self] in
       do {
         guard let `self` = self else {
@@ -263,7 +263,7 @@ extension CacheManager {
         }
         self.frontStorage.clear()
         try self.backStorage.clear()
-        if keepingDirectory {
+        if keepingRootDirectory {
           try self.backStorage.createDirectory()
         }
         completion?(nil)
@@ -369,14 +369,14 @@ extension CacheManager {
 
   /**
    Clears the front and back cache storages.
-   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   - Parameter keepingRootDirectory: Pass `true` to keep the existing disk cache directory
    after removing its contents. The default value is `false`.
    */
-  func clear(keepingDirectory: Bool = false) throws {
+  func clear(keepingRootDirectory: Bool = false) throws {
     try writeQueue.sync { [weak self] in
       self?.frontStorage.clear()
       try self?.backStorage.clear()
-      if keepingDirectory {
+      if keepingRootDirectory {
         try self?.backStorage.createDirectory()
       }
     }

--- a/Source/Shared/Cache/HybridCache.swift
+++ b/Source/Shared/Cache/HybridCache.swift
@@ -45,11 +45,11 @@ public class HybridCache: BasicHybridCache {
 
   /**
    Clears the front and back cache storages.
-   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   - Parameter keepingRootDirectory: Pass `true` to keep the existing disk cache directory
    after removing its contents. The default value is `false`.
    */
-  public func clear(keepingDirectory: Bool = false) throws {
-    try manager.clear(keepingDirectory: keepingDirectory)
+  public func clear(keepingRootDirectory: Bool = false) throws {
+    try manager.clear(keepingRootDirectory: keepingRootDirectory)
   }
 
   /**
@@ -114,12 +114,12 @@ public class AsyncHybridCache {
 
   /**
    Clears the front and back cache storages.
-   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   - Parameter keepingRootDirectory: Pass `true` to keep the existing disk cache directory
    after removing its contents. The default value is `false`.
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func clear(keepingDirectory: Bool = false, completion: Completion? = nil) {
-    manager.clear(keepingDirectory: keepingDirectory, completion: completion)
+  public func clear(keepingRootDirectory: Bool = false, completion: Completion? = nil) {
+    manager.clear(keepingRootDirectory: keepingRootDirectory, completion: completion)
   }
 
   /**

--- a/Source/Shared/Cache/HybridCache.swift
+++ b/Source/Shared/Cache/HybridCache.swift
@@ -45,9 +45,11 @@ public class HybridCache: BasicHybridCache {
 
   /**
    Clears the front and back cache storages.
+   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   after removing its contents. The default value is `false`.
    */
-  public func clear() throws {
-    try manager.clear()
+  public func clear(keepingDirectory: Bool = false) throws {
+    try manager.clear(keepingDirectory: keepingDirectory)
   }
 
   /**
@@ -112,10 +114,12 @@ public class AsyncHybridCache {
 
   /**
    Clears the front and back cache storages.
+   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   after removing its contents. The default value is `false`.
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func clear(completion: Completion? = nil) {
-    manager.clear(completion: completion)
+  public func clear(keepingDirectory: Bool = false, completion: Completion? = nil) {
+    manager.clear(keepingDirectory: keepingDirectory, completion: completion)
   }
 
   /**

--- a/Source/Shared/Cache/SpecializedCache.swift
+++ b/Source/Shared/Cache/SpecializedCache.swift
@@ -69,9 +69,11 @@ public final class SpecializedCache<T: Cachable>: BasicHybridCache {
 
   /**
    Clears the front and back cache storages.
+   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   after removing its contents. The default value is `false`.
    */
-  public func clear() throws {
-    try manager.clear()
+  public func clear(keepingDirectory: Bool = false) throws {
+    try manager.clear(keepingDirectory: keepingDirectory)
   }
 
   /**
@@ -136,10 +138,12 @@ public class AsyncSpecializedCache<T: Cachable> {
 
   /**
    Clears the front and back cache storages.
+   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   after removing its contents. The default value is `false`.
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func clear(completion: Completion? = nil) {
-    manager.clear(completion: completion)
+  public func clear(keepingDirectory: Bool = false, completion: Completion? = nil) {
+    manager.clear(keepingDirectory: keepingDirectory, completion: completion)
   }
 
   /**

--- a/Source/Shared/Cache/SpecializedCache.swift
+++ b/Source/Shared/Cache/SpecializedCache.swift
@@ -69,11 +69,11 @@ public final class SpecializedCache<T: Cachable>: BasicHybridCache {
 
   /**
    Clears the front and back cache storages.
-   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   - Parameter keepingRootDirectory: Pass `true` to keep the existing disk cache directory
    after removing its contents. The default value is `false`.
    */
-  public func clear(keepingDirectory: Bool = false) throws {
-    try manager.clear(keepingDirectory: keepingDirectory)
+  public func clear(keepingRootDirectory: Bool = false) throws {
+    try manager.clear(keepingRootDirectory: keepingRootDirectory)
   }
 
   /**
@@ -138,12 +138,12 @@ public class AsyncSpecializedCache<T: Cachable> {
 
   /**
    Clears the front and back cache storages.
-   - Parameter keepingDirectory: Pass `true` to keep the existing disk cache directory
+   - Parameter keepingRootDirectory: Pass `true` to keep the existing disk cache directory
    after removing its contents. The default value is `false`.
    - Parameter completion: Completion closure to be called when the task is done
    */
-  public func clear(keepingDirectory: Bool = false, completion: Completion? = nil) {
-    manager.clear(keepingDirectory: keepingDirectory, completion: completion)
+  public func clear(keepingRootDirectory: Bool = false, completion: Completion? = nil) {
+    manager.clear(keepingRootDirectory: keepingRootDirectory, completion: completion)
   }
 
   /**

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -37,11 +37,9 @@ final class DiskStorage: StorageAware {
         path = url.appendingPathComponent(name, isDirectory: true).path
       }
 
-      if !fileManager.fileExists(atPath: path) {
-        try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
-      }
+      try createDirectory()
     } catch {
-      fatalError("Failed to find or get acces to caches directory: \(error)")
+      fatalError("Failed to find or get access to caches directory: \(error)")
     }
   }
 
@@ -127,6 +125,12 @@ final class DiskStorage: StorageAware {
    */
   func clear() throws {
     try fileManager.removeItem(atPath: path)
+  }
+
+  func createDirectory() throws {
+    if !fileManager.fileExists(atPath: path) {
+      try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+    }
   }
 
   private typealias ResourceObject = (url: Foundation.URL, resourceValues: [AnyHashable: Any])

--- a/Tests/iOS/Tests/Cache/HybridCacheTests.swift
+++ b/Tests/iOS/Tests/Cache/HybridCacheTests.swift
@@ -183,14 +183,14 @@ final class HybridCacheTests: XCTestCase {
   }
 
   /// Test that it clears cached files, but keeps root directory
-  func testAsyncClearKeepingDirectory() throws {
+  func testAsyncClearKeepingRootDirectory() throws {
     let expectation1 = self.expectation(description: "Clear Expectation")
 
     cache.async.addObject(object, forKey: key) { error in
       if let error = error {
         XCTFail("Failed with error: \(error)")
       }
-      self.cache.async.clear(keepingDirectory: true) { error in
+      self.cache.async.clear(keepingRootDirectory: true) { error in
         if let error = error {
           XCTFail("Failed with error: \(error)")
         }
@@ -320,9 +320,9 @@ final class HybridCacheTests: XCTestCase {
   }
 
   /// Test that it clears cached files, but keeps root directory
-  func testClearKeepingDirectory() throws {
+  func testClearKeepingRootDirectory() throws {
     try cache.addObject(object, forKey: key)
-    try cache.clear(keepingDirectory: true)
+    try cache.clear(keepingRootDirectory: true)
     XCTAssertNil(cache.object(forKey: key) as String?)
     XCTAssertTrue(fileManager.fileExists(atPath: cache.manager.backStorage.path))
   }

--- a/Tests/iOS/Tests/Cache/HybridCacheTests.swift
+++ b/Tests/iOS/Tests/Cache/HybridCacheTests.swift
@@ -6,6 +6,7 @@ final class HybridCacheTests: XCTestCase {
   private let key = "alongweirdkey"
   private let object = "Test"
   private var cache: HybridCache!
+  private let fileManager = FileManager()
 
   override func setUp() {
     super.setUp()
@@ -181,6 +182,29 @@ final class HybridCacheTests: XCTestCase {
     self.waitForExpectations(timeout: 1.0, handler:nil)
   }
 
+  /// Test that it clears cached files, but keeps root directory
+  func testAsyncClearKeepingDirectory() throws {
+    let expectation1 = self.expectation(description: "Clear Expectation")
+
+    cache.async.addObject(object, forKey: key) { error in
+      if let error = error {
+        XCTFail("Failed with error: \(error)")
+      }
+      self.cache.async.clear(keepingDirectory: true) { error in
+        if let error = error {
+          XCTFail("Failed with error: \(error)")
+        }
+
+        self.cache.async.object(forKey: self.key) { (cachedObject: String?) in
+          XCTAssertNil(cachedObject)
+          XCTAssertTrue(self.fileManager.fileExists(atPath: self.cache.manager.backStorage.path))
+          expectation1.fulfill()
+        }
+      }
+    }
+    self.waitForExpectations(timeout: 1.0, handler:nil)
+  }
+
   /// Clears expired objects from memory and disk cache
   func testAsyncClearExpired() {
     let expectation1 = self.expectation(description: "Clear If Expired Expectation")
@@ -293,6 +317,14 @@ final class HybridCacheTests: XCTestCase {
       diskObject = try self.cache.manager.backStorage.object(forKey: self.key)
     } catch {}
     XCTAssertNil(diskObject)
+  }
+
+  /// Test that it clears cached files, but keeps root directory
+  func testClearKeepingDirectory() throws {
+    try cache.addObject(object, forKey: key)
+    try cache.clear(keepingDirectory: true)
+    XCTAssertNil(cache.object(forKey: key) as String?)
+    XCTAssertTrue(fileManager.fileExists(atPath: cache.manager.backStorage.path))
   }
 
   /// Clears expired objects from memory and disk cache

--- a/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
+++ b/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
@@ -6,6 +6,7 @@ final class SpecializedCacheTests: XCTestCase {
   private let key = "alongweirdkey"
   private let object = TestHelper.user
   private var cache: SpecializedCache<User>!
+  private let fileManager = FileManager()
 
   override func setUp() {
     super.setUp()
@@ -185,6 +186,29 @@ final class SpecializedCacheTests: XCTestCase {
     self.waitForExpectations(timeout: 1.0, handler:nil)
   }
 
+  /// Test that it clears cached files, but keeps root directory
+  func testAsyncClearKeepingDirectory() throws {
+    let expectation1 = self.expectation(description: "Clear Expectation")
+
+    cache.async.addObject(object, forKey: key) { error in
+      if let error = error {
+        XCTFail("Failed with error: \(error)")
+      }
+      self.cache.async.clear(keepingDirectory: true) { error in
+        if let error = error {
+          XCTFail("Failed with error: \(error)")
+        }
+
+        self.cache.async.object(forKey: self.key) { object in
+          XCTAssertNil(object)
+          XCTAssertTrue(self.fileManager.fileExists(atPath: self.cache.manager.backStorage.path))
+          expectation1.fulfill()
+        }
+      }
+    }
+    self.waitForExpectations(timeout: 1.0, handler:nil)
+  }
+
   /// Clears expired objects from memory and disk cache
   func testAsyncClearExpired() {
     let expectation1 = self.expectation(description: "Clear If Expired Expectation")
@@ -320,6 +344,14 @@ final class SpecializedCacheTests: XCTestCase {
       diskObject = try self.cache.manager.backStorage.object(forKey: self.key)
     } catch {}
     XCTAssertNil(diskObject)
+  }
+
+  /// Test that it clears cached files, but keeps root directory
+  func testClearKeepingDirectory() throws {
+    try cache.addObject(object, forKey: key)
+    try cache.clear(keepingDirectory: true)
+    XCTAssertNil(cache.object(forKey: key))
+    XCTAssertTrue(fileManager.fileExists(atPath: cache.manager.backStorage.path))
   }
 
   /// Clears expired objects from memory and disk cache

--- a/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
+++ b/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
@@ -187,14 +187,14 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   /// Test that it clears cached files, but keeps root directory
-  func testAsyncClearKeepingDirectory() throws {
+  func testAsyncClearKeepingRootDirectory() throws {
     let expectation1 = self.expectation(description: "Clear Expectation")
 
     cache.async.addObject(object, forKey: key) { error in
       if let error = error {
         XCTFail("Failed with error: \(error)")
       }
-      self.cache.async.clear(keepingDirectory: true) { error in
+      self.cache.async.clear(keepingRootDirectory: true) { error in
         if let error = error {
           XCTFail("Failed with error: \(error)")
         }
@@ -347,9 +347,9 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   /// Test that it clears cached files, but keeps root directory
-  func testClearKeepingDirectory() throws {
+  func testClearKeepingRootDirectory() throws {
     try cache.addObject(object, forKey: key)
-    try cache.clear(keepingDirectory: true)
+    try cache.clear(keepingRootDirectory: true)
     XCTAssertNil(cache.object(forKey: key))
     XCTAssertTrue(fileManager.fileExists(atPath: cache.manager.backStorage.path))
   }

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -132,6 +132,15 @@ final class DiskStorageTests: XCTestCase {
     XCTAssertFalse(fileExist)
   }
 
+  /// Test that it clears cache files, but keeps root directory
+  func testCreateDirectory() throws {
+    try storage.clear()
+    XCTAssertFalse(fileManager.fileExists(atPath: storage.path))
+
+    try storage.createDirectory()
+    XCTAssertTrue(fileManager.fileExists(atPath: storage.path))
+  }
+
   /// Test that it removes expired objects
   func testClearExpired() throws {
     let expiry1: Expiry = .date(Date().addingTimeInterval(-100000))


### PR DESCRIPTION
Sometimes it's useful to keep the existing disk cache directory after removing its contents.

```swift
// Pass `true` to keep the existing disk cache directory after removing
// its contents. The default value for `keepingRootDirectory` is `false`.
try cache.clear(keepingRootDirectory: true)
```