### PR TITLE
Pin SwiftHash version to avoid Swift 4 upgrade

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "onmyway133/SwiftHash"
+github "onmyway133/SwiftHash" == 1.4


### PR DESCRIPTION
SwiftHash 1.5.0 is out now which upgrades to Swift 4.