### PR TITLE
Changed SwiftHash version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "onmyway133/SwiftHash" == 1.4
+github "onmyway133/SwiftHash" == 1.4.0


### PR DESCRIPTION
Hi,
I am having trouble with this. Here a discussion about the errors we get:

[](https://github.com/onmyway133/SwiftHash/issues/7#issuecomment-307634707)

Anyway, the fix that onmyway133 suggested is that we specify the version to 1.4.0.

I see that you had the 1.4 maybe somehow is not the same? As Carthage docs `== 1.0 for “exactly version 1.0”` which maybe 1.4 is not 1.4.0. Logically is the same, programatically maybe is not.