### PR TITLE
Add `isEnabled` property on Logger

### DIFF
--- a/Source/Shared/Library/Logger.swift
+++ b/Source/Shared/Library/Logger.swift
@@ -9,9 +9,9 @@ class Logger {
   // It is disabled by default but you can always catch errors
   // using Swift Error break points even if the feature is
   // disabled.
-  static var enabled: Bool = false
+  static var isEnabled: Bool = false
   static func log(error: Error) {
-    guard Logger.enabled else {
+    guard Logger.isEnabled else {
       return
     }
 

--- a/Source/Shared/Library/Logger.swift
+++ b/Source/Shared/Library/Logger.swift
@@ -1,5 +1,20 @@
-struct Logger {
+import Foundation
+
+// A message logger that prints errors when ever `Cache` is unable to perform its
+// operation. Usually when ever a method throws. You can eanble `Logger` by setting
+// `Logger.enabled` to `true`. However, if you don't want to debug using print statements
+// you can capture errors by enabling `Swift Error break points`
+class Logger {
+  // When `Logger` is enabled it will print `Cache` errors to the console.
+  // It is disabled by default but you can always catch errors
+  // using Swift Error break points even if the feature is
+  // disabled.
+  static var enabled: Bool = false
   static func log(error: Error) {
-    print("📦 Cache: \(error)")
+    guard Logger.enabled else {
+      return
+    }
+
+    NSLog("📦 Cache: \(error)")
   }
 }

--- a/Source/Shared/Library/Logger.swift
+++ b/Source/Shared/Library/Logger.swift
@@ -4,12 +4,12 @@ import Foundation
 // operation. Usually when ever a method throws. You can eanble `Logger` by setting
 // `Logger.enabled` to `true`. However, if you don't want to debug using print statements
 // you can capture errors by enabling `Swift Error break points`
-class Logger {
+public class Logger {
   // When `Logger` is enabled it will print `Cache` errors to the console.
   // It is disabled by default but you can always catch errors
   // using Swift Error break points even if the feature is
   // disabled.
-  static var isEnabled: Bool = false
+  public static var isEnabled: Bool = false
   static func log(error: Error) {
     guard Logger.isEnabled else {
       return


### PR DESCRIPTION
Adds a property on `Logger` to enabled logging. When ever `log(error: Error)` is called it will check if the feature is enabled or not. If enabled it will print to the console. This will no use `NSLog` instead of `print` as that will log to the device console which `print` does not. It should improve the debugging experience if you debug on a device using the device console.

Fixes https://github.com/hyperoslo/Cache/issues/108