### PR TITLE
Implement expiration mode on `Config`

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		BDEDD37D1DBCEB8A007416A6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDEDD3561DBCE5B1007416A6 /* Cache.framework */; };
 		BDEDD3831DBCEBC4007416A6 /* TestHelper+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291CDF1C28374800B702C9 /* TestHelper+iOS.swift */; };
 		BDEDD3851DBCEBC4007416A6 /* UIImage+CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291DA01C28405900B702C9 /* UIImage+CacheTests.swift */; };
+		BDF64BC71F54764700134105 /* ExpirationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF64BC61F54764700134105 /* ExpirationMode.swift */; };
+		BDF64BC81F54764700134105 /* ExpirationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF64BC61F54764700134105 /* ExpirationMode.swift */; };
+		BDF64BC91F54764700134105 /* ExpirationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF64BC61F54764700134105 /* ExpirationMode.swift */; };
 		D5291C2D1C28220B00B702C9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C151C28220B00B702C9 /* Config.swift */; };
 		D5291C2E1C28220B00B702C9 /* Cachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C171C28220B00B702C9 /* Cachable.swift */; };
 		D5291C2F1C28220B00B702C9 /* Capsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C181C28220B00B702C9 /* Capsule.swift */; };
@@ -160,6 +163,7 @@
 		57506FAD1EC29437009B71E9 /* CacheEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheEntry.swift; sourceTree = "<group>"; };
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BDF64BC61F54764700134105 /* ExpirationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationMode.swift; sourceTree = "<group>"; };
 		D5291C151C28220B00B702C9 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D5291C171C28220B00B702C9 /* Cachable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cachable.swift; sourceTree = "<group>"; };
 		D5291C181C28220B00B702C9 /* Capsule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Capsule.swift; sourceTree = "<group>"; };
@@ -297,11 +301,11 @@
 			isa = PBXGroup;
 			children = (
 				D5291C171C28220B00B702C9 /* Cachable.swift */,
+				D5C24E211EE9D4CF00D2CF22 /* CacheArray.swift */,
 				D5291C181C28220B00B702C9 /* Capsule.swift */,
 				D5CE966C1EE475C0002BFE06 /* Coding.swift */,
 				D5291C191C28220B00B702C9 /* Expiry.swift */,
 				D5291C1A1C28220B00B702C9 /* JSON.swift */,
-				D5C24E211EE9D4CF00D2CF22 /* CacheArray.swift */,
 			);
 			path = DataStructures;
 			sourceTree = "<group>";
@@ -466,6 +470,7 @@
 			children = (
 				D5CE968C1EE69969002BFE06 /* BasicHybridCache.swift */,
 				D5FAF3881EE6F956000A71A8 /* CacheManager.swift */,
+				BDF64BC61F54764700134105 /* ExpirationMode.swift */,
 				D5CE968B1EE69969002BFE06 /* HybridCache.swift */,
 				D5CE968A1EE69969002BFE06 /* SpecializedCache.swift */,
 			);
@@ -850,6 +855,7 @@
 				BDEDD3621DBCE5CE007416A6 /* Config.swift in Sources */,
 				D5CE96951EE69969002BFE06 /* BasicHybridCache.swift in Sources */,
 				D5CE966F1EE475C0002BFE06 /* Coding.swift in Sources */,
+				BDF64BC91F54764700134105 /* ExpirationMode.swift in Sources */,
 				BDEDD36B1DBCE5D8007416A6 /* String+Cache.swift in Sources */,
 				BDEDD36A1DBCE5D8007416A6 /* Date+Cache.swift in Sources */,
 				D5FAF38B1EE6F956000A71A8 /* CacheManager.swift in Sources */,
@@ -930,6 +936,7 @@
 				D5CE966E1EE475C0002BFE06 /* Coding.swift in Sources */,
 				D5CE96941EE69969002BFE06 /* BasicHybridCache.swift in Sources */,
 				D5291D881C283CFB00B702C9 /* Config.swift in Sources */,
+				BDF64BC81F54764700134105 /* ExpirationMode.swift in Sources */,
 				D5291D951C283CFB00B702C9 /* StorageAware.swift in Sources */,
 				D5291D911C283CFB00B702C9 /* String+Cache.swift in Sources */,
 				D5FAF38A1EE6F956000A71A8 /* CacheManager.swift in Sources */,
@@ -984,6 +991,7 @@
 				D5291C391C28220B00B702C9 /* MemoryStorage.swift in Sources */,
 				D5CE966D1EE475C0002BFE06 /* Coding.swift in Sources */,
 				D5CE96931EE69969002BFE06 /* BasicHybridCache.swift in Sources */,
+				BDF64BC71F54764700134105 /* ExpirationMode.swift in Sources */,
 				D5291C351C28220B00B702C9 /* Date+Cache.swift in Sources */,
 				D5291C301C28220B00B702C9 /* Expiry.swift in Sources */,
 				D5FAF3891EE6F956000A71A8 /* CacheManager.swift in Sources */,

--- a/Source/Shared/Cache/CacheManager.swift
+++ b/Source/Shared/Cache/CacheManager.swift
@@ -68,9 +68,16 @@ class CacheManager: NSObject {
     readQueue = DispatchQueue(label: "\(queuePrefix).ReadQueue", attributes: [])
 
     super.init()
+
+    guard config.expirationMode == .auto else {
+      return
+    }
+
     let notificationCenter = NotificationCenter.default
 
     #if os(macOS)
+      notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInFrontStorage),
+                                     name: NSNotification.Name.NSApplicationWillTerminate, object: nil)
       notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
                                      name: NSNotification.Name.NSApplicationWillTerminate, object: nil)
       notificationCenter.addObserver(self, selector: #selector(clearExpiredDataInBackStorage),
@@ -101,6 +108,10 @@ class CacheManager: NSObject {
    Clears expired cache items when the app enters background.
    */
   @objc private func applicationDidEnterBackground() {
+    guard config.expirationMode == .auto else {
+      return
+    }
+
     let application = UIApplication.shared
     var backgroundTask: UIBackgroundTaskIdentifier?
 

--- a/Source/Shared/Cache/ExpirationMode.swift
+++ b/Source/Shared/Cache/ExpirationMode.swift
@@ -1,0 +1,10 @@
+/// Sets the expiration mode for the `CacheManager`. The default value is `.auto` which means that `Cache`
+/// will handle expiration internally. It will trigger cache clean up tasks depending on the events its receives
+/// from the application. If expiration mode is set to manual, it means that you manually have to invoke the clear
+/// cache methods yourself.
+///
+/// - auto: Automatic cleanup of expired objects (default).
+/// - manual: Manual means that you opt out from any automatic expiration handling.
+public enum ExpirationMode {
+  case auto, manual
+}

--- a/Source/Shared/Config.swift
+++ b/Source/Shared/Config.swift
@@ -15,6 +15,8 @@ public struct Config {
   public let maxDiskSize: UInt
   /// A folder to store the disk cache contents. Defaults to a prefixed directory in Caches if nil
   public let cacheDirectory: String?
+  /// Determines if the cache manager should clear expired objects or if this should be handled manually.
+  public let expirationMode: ExpirationMode
 
   // MARK: - Initialization
 
@@ -30,11 +32,13 @@ public struct Config {
               memoryCountLimit: UInt = 0,
               memoryTotalCostLimit: UInt = 0,
               maxDiskSize: UInt = 0,
-              cacheDirectory: String? = nil) {
+              cacheDirectory: String? = nil,
+              expirationMode: ExpirationMode = .auto) {
     self.expiry = expiry
     self.memoryCountLimit = memoryCountLimit
     self.memoryTotalCostLimit = memoryTotalCostLimit
     self.maxDiskSize = maxDiskSize
     self.cacheDirectory = cacheDirectory
+    self.expirationMode = expirationMode
   }
 }

--- a/Tests/TestHelper.swift
+++ b/Tests/TestHelper.swift
@@ -9,4 +9,14 @@ struct TestHelper {
     let buffer = [UInt8](repeating: 0, count: length)
     return Data(bytes: buffer)
   }
+
+  static func triggerApplicationEvents() {
+    #if !os(macOS)
+      NotificationCenter.default.post(name: .UIApplicationDidEnterBackground, object: nil)
+      NotificationCenter.default.post(name: .UIApplicationWillTerminate, object: nil)
+    #else
+      NotificationCenter.default.post(name: NSNotification.Name.NSApplicationWillTerminate, object: nil)
+      NotificationCenter.default.post(name: NSNotification.Name.NSApplicationDidResignActive, object: nil)
+    #endif
+  }
 }

--- a/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
+++ b/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
@@ -10,16 +10,19 @@ final class SpecializedCacheTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    cache = SpecializedCache<User>(name: cacheName)
+
   }
 
   override func tearDown() {
-    try? cache.clear()
+    if cache != nil {
+      try? cache.clear()
+    }
     super.tearDown()
   }
 
   func testInit() {
     let defaultConfig = Config()
+    cache = SpecializedCache<User>(name: cacheName)
 
     XCTAssertEqual(cache.name, cacheName)
     XCTAssertEqual(cache.manager.config.expiry.date, defaultConfig.expiry.date)
@@ -33,6 +36,7 @@ final class SpecializedCacheTests: XCTestCase {
   // MARK: - Async caching
 
   func testAsyncAddObject() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation1 = self.expectation(description: "Save Expectation")
     let expectation2 = self.expectation(description: "Save To Memory Expectation")
     let expectation3 = self.expectation(description: "Save To Disk Expectation")
@@ -61,6 +65,7 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   func testAsyncCacheEntry() {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation = self.expectation(description: "Save Expectation")
     let expiryDate = Date()
     cache.async.addObject(object, forKey: key, expiry: .date(expiryDate)) { error in
@@ -79,6 +84,7 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   func testAsyncObject() {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation = self.expectation(description: "Expectation")
     cache.async.addObject(object, forKey: key) { error in
       if let error = error {
@@ -96,6 +102,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Should resolve from disk and set in-memory cache if object not in-memory
   func testAsyncObjectCopyToMemory() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation = self.expectation(description: "Expectation")
 
     try cache.manager.backStorage.addObject(object, forKey: key)
@@ -116,6 +123,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Removes cached object from memory and disk
   func testAsyncRemoveObject() {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation1 = self.expectation(description: "Remove Expectation")
     let expectation2 = self.expectation(description: "Remove From Memory Expectation")
     let expectation3 = self.expectation(description: "Remove From Disk Expectation")
@@ -153,6 +161,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Clears memory and disk cache
   func testAsyncClear() {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation1 = self.expectation(description: "Clear Expectation")
     let expectation2 = self.expectation(description: "Clear Memory Expectation")
     let expectation3 = self.expectation(description: "Clear Disk Expectation")
@@ -188,6 +197,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Test that it clears cached files, but keeps root directory
   func testAsyncClearKeepingRootDirectory() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation1 = self.expectation(description: "Clear Expectation")
 
     cache.async.addObject(object, forKey: key) { error in
@@ -211,6 +221,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Clears expired objects from memory and disk cache
   func testAsyncClearExpired() {
+    cache = SpecializedCache<User>(name: cacheName)
     let expectation1 = self.expectation(description: "Clear If Expired Expectation")
     let expectation2 = self.expectation(description: "Don't Clear If Not Expired Expectation")
     let expiry1: Expiry = .date(Date().addingTimeInterval(-100000))
@@ -248,6 +259,7 @@ final class SpecializedCacheTests: XCTestCase {
   // MARK: - Sync caching
 
   func testSubscript() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     XCTAssertNil(cache[key])
     // Add
     cache[key] = object
@@ -267,6 +279,7 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   func testAdd() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     try cache.addObject(object, forKey: key)
     let cachedObject = cache.object(forKey: key)
     XCTAssertNotNil(cachedObject)
@@ -279,6 +292,7 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   func testCacheEntry() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     let expiryDate = Date()
     try cache.addObject(object, forKey: key, expiry: .date(expiryDate))
     let entry = cache.cacheEntry(forKey: key)
@@ -289,6 +303,7 @@ final class SpecializedCacheTests: XCTestCase {
   }
 
   func testObject() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     try cache.addObject(object, forKey: key)
     let cachedObject = cache.object(forKey: key)
 
@@ -299,6 +314,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Should resolve from disk and set in-memory cache if object not in-memory
   func testObjectCopyToMemory() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     try cache.manager.backStorage.addObject(object, forKey: key)
     let cachedObject = cache.object(forKey: key)
 
@@ -313,6 +329,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Removes cached object from memory and disk
   func testRemoveObject() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     try cache.addObject(object, forKey: key)
     XCTAssertNotNil(cache.object(forKey: key))
 
@@ -332,6 +349,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Clears memory and disk cache
   func testClear() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     try cache.addObject(object, forKey: key)
     try cache.clear()
     XCTAssertNil(cache.object(forKey: key))
@@ -348,6 +366,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Test that it clears cached files, but keeps root directory
   func testClearKeepingRootDirectory() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     try cache.addObject(object, forKey: key)
     try cache.clear(keepingRootDirectory: true)
     XCTAssertNil(cache.object(forKey: key))
@@ -356,6 +375,7 @@ final class SpecializedCacheTests: XCTestCase {
 
   /// Clears expired objects from memory and disk cache
   func testClearExpired() throws {
+    cache = SpecializedCache<User>(name: cacheName)
     let expiry1: Expiry = .date(Date().addingTimeInterval(-100000))
     let expiry2: Expiry = .date(Date().addingTimeInterval(100000))
     let key1 = "key1"
@@ -374,5 +394,34 @@ final class SpecializedCacheTests: XCTestCase {
     try cache.addObject(TestHelper.data(20), forKey: "key2")
     let size = try cache.totalDiskSize()
     XCTAssertEqual(size, 30)
+  }
+
+  func testAutoExpirationMode() throws {
+    let config = Config(expirationMode: .auto)
+    let expiry: Expiry = .date(Date().addingTimeInterval(-100000))
+    let cache = SpecializedCache<Data>(name: cacheName, config: config)
+    let key = "auto-key"
+    let expectation = self.expectation(description: "Wait for async cleanup")
+
+    try cache.addObject(TestHelper.data(10), forKey: key, expiry: expiry)
+    TestHelper.triggerApplicationEvents()
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      XCTAssertNil(cache.object(forKey: key))
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 10.0)
+  }
+
+  func testExpirationManualMode() throws {
+    let config = Config(expirationMode: .manual)
+    let expiry: Expiry = .date(Date().addingTimeInterval(-100000))
+    let manualCache = SpecializedCache<Data>(name: cacheName, config: config)
+    let key = "manual-key"
+
+    try manualCache.addObject(TestHelper.data(10), forKey: key, expiry: expiry)
+    TestHelper.triggerApplicationEvents()
+    XCTAssertNotNil(manualCache.object(forKey: key))
   }
 }

--- a/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
+++ b/Tests/iOS/Tests/Cache/SpecializedCacheTests.swift
@@ -411,7 +411,7 @@ final class SpecializedCacheTests: XCTestCase {
       expectation.fulfill()
     }
 
-    wait(for: [expectation], timeout: 10.0)
+    self.waitForExpectations(timeout: 10.0, handler:nil)
   }
 
   func testExpirationManualMode() throws {


### PR DESCRIPTION
Implements a new configuration option for opting out from using the internal expiration cleanup mechanism in `Cache`.

Expiration mode lives on `Config` and is used by `CacheManager`. When the expiration mode is set to `.auto`, `Cache` will handle the cleanup of expired objects. When set to `.manual`, it means that you will manually handle expired objects.

This should be a non-breaking change as `.auto` is the default.

Attempting to solve: https://github.com/hyperoslo/Cache/issues/116