### PR TITLE
Add storage tests

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		BDEDD3621DBCE5CE007416A6 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C151C28220B00B702C9 /* Config.swift */; };
 		BDEDD37D1DBCEB8A007416A6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDEDD3561DBCE5B1007416A6 /* Cache.framework */; };
+		D21AD6141F681128003A8172 /* CapsuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59A19AF1EE8246F009F6AEE /* CapsuleTests.swift */; };
+		D21AD6161F68112E003A8172 /* ExpiryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59A19B11EE8246F009F6AEE /* ExpiryTests.swift */; };
 		D28C9B6C1F67D4D500C180C1 /* Expiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C191C28220B00B702C9 /* Expiry.swift */; };
 		D28C9B6D1F67D4D800C180C1 /* Capsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C181C28220B00B702C9 /* Capsule.swift */; };
 		D28C9B6E1F67D4DE00C180C1 /* Date+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C1F1C28220B00B702C9 /* Date+Cache.swift */; };
@@ -810,10 +812,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D21AD6161F68112E003A8172 /* ExpiryTests.swift in Sources */,
 				D28C9BAD1F67ED0000C180C1 /* User.swift in Sources */,
 				D28C9BAE1F67ED5500C180C1 /* TestHelper.swift in Sources */,
 				D28C9BA71F67E3D400C180C1 /* ImageWrapperTests.swift in Sources */,
 				D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */,
+				D21AD6141F681128003A8172 /* CapsuleTests.swift in Sources */,
 				D28C9BAF1F67EF8300C180C1 /* UIImage+CacheTests.swift in Sources */,
 				D28C9BA91F67E3E000C180C1 /* PrimitiveWrapperTests.swift in Sources */,
 			);

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BDEDD37D1DBCEB8A007416A6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDEDD3561DBCE5B1007416A6 /* Cache.framework */; };
 		D21AD6141F681128003A8172 /* CapsuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59A19AF1EE8246F009F6AEE /* CapsuleTests.swift */; };
 		D21AD6161F68112E003A8172 /* ExpiryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59A19B11EE8246F009F6AEE /* ExpiryTests.swift */; };
+		D21AD6181F6811E9003A8172 /* MemoryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AD6171F6811E9003A8172 /* MemoryStorageTests.swift */; };
 		D28C9B6C1F67D4D500C180C1 /* Expiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C191C28220B00B702C9 /* Expiry.swift */; };
 		D28C9B6D1F67D4D800C180C1 /* Capsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C181C28220B00B702C9 /* Capsule.swift */; };
 		D28C9B6E1F67D4DE00C180C1 /* Date+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C1F1C28220B00B702C9 /* Date+Cache.swift */; };
@@ -73,6 +74,7 @@
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDF64BC61F54764700134105 /* ExpirationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationMode.swift; sourceTree = "<group>"; };
+		D21AD6171F6811E9003A8172 /* MemoryStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorageTests.swift; sourceTree = "<group>"; };
 		D28C9B7F1F67E38C00C180C1 /* CacheError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheError.swift; sourceTree = "<group>"; };
 		D28C9B801F67E38C00C180C1 /* DataSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializer.swift; sourceTree = "<group>"; };
 		D28C9B811F67E38C00C180C1 /* DiskConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskConfig.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 			children = (
 				D28C9BA61F67E3D400C180C1 /* ImageWrapperTests.swift */,
 				D28C9BA81F67E3E000C180C1 /* PrimitiveWrapperTests.swift */,
+				D21AD6171F6811E9003A8172 /* MemoryStorageTests.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -813,6 +816,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D21AD6161F68112E003A8172 /* ExpiryTests.swift in Sources */,
+				D21AD6181F6811E9003A8172 /* MemoryStorageTests.swift in Sources */,
 				D28C9BAD1F67ED0000C180C1 /* User.swift in Sources */,
 				D28C9BAE1F67ED5500C180C1 /* TestHelper.swift in Sources */,
 				D28C9BA71F67E3D400C180C1 /* ImageWrapperTests.swift in Sources */,

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		D21AD6141F681128003A8172 /* CapsuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59A19AF1EE8246F009F6AEE /* CapsuleTests.swift */; };
 		D21AD6161F68112E003A8172 /* ExpiryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59A19B11EE8246F009F6AEE /* ExpiryTests.swift */; };
 		D21AD6181F6811E9003A8172 /* MemoryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AD6171F6811E9003A8172 /* MemoryStorageTests.swift */; };
+		D21AD61A1F681784003A8172 /* DiskStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AD6191F681784003A8172 /* DiskStorageTests.swift */; };
 		D28C9B6C1F67D4D500C180C1 /* Expiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C191C28220B00B702C9 /* Expiry.swift */; };
 		D28C9B6D1F67D4D800C180C1 /* Capsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C181C28220B00B702C9 /* Capsule.swift */; };
 		D28C9B6E1F67D4DE00C180C1 /* Date+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291C1F1C28220B00B702C9 /* Date+Cache.swift */; };
@@ -75,6 +76,7 @@
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDF64BC61F54764700134105 /* ExpirationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationMode.swift; sourceTree = "<group>"; };
 		D21AD6171F6811E9003A8172 /* MemoryStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorageTests.swift; sourceTree = "<group>"; };
+		D21AD6191F681784003A8172 /* DiskStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorageTests.swift; sourceTree = "<group>"; };
 		D28C9B7F1F67E38C00C180C1 /* CacheError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheError.swift; sourceTree = "<group>"; };
 		D28C9B801F67E38C00C180C1 /* DataSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializer.swift; sourceTree = "<group>"; };
 		D28C9B811F67E38C00C180C1 /* DiskConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskConfig.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				D28C9BA61F67E3D400C180C1 /* ImageWrapperTests.swift */,
 				D28C9BA81F67E3E000C180C1 /* PrimitiveWrapperTests.swift */,
 				D21AD6171F6811E9003A8172 /* MemoryStorageTests.swift */,
+				D21AD6191F681784003A8172 /* DiskStorageTests.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -821,6 +824,7 @@
 				D28C9BAE1F67ED5500C180C1 /* TestHelper.swift in Sources */,
 				D28C9BA71F67E3D400C180C1 /* ImageWrapperTests.swift in Sources */,
 				D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */,
+				D21AD61A1F681784003A8172 /* DiskStorageTests.swift in Sources */,
 				D21AD6141F681128003A8172 /* CapsuleTests.swift in Sources */,
 				D28C9BAF1F67EF8300C180C1 /* UIImage+CacheTests.swift in Sources */,
 				D28C9BA91F67E3E000C180C1 /* PrimitiveWrapperTests.swift in Sources */,

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -22,16 +22,17 @@ final class DiskStorage {
     self.config = config
     self.fileManager = fileManager
 
+    let url: URL
     if let directory = config.directory {
-      self.path = directory.absoluteString
+      url = directory
     } else {
-      let url = try fileManager.url(
+      url = try fileManager.url(
         for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true
       )
-
-      path = url.appendingPathComponent(config.name, isDirectory: true).path
-      try createDirectory()
     }
+
+    path = url.appendingPathComponent(config.name, isDirectory: true).path
+    try createDirectory()
   }
 }
 
@@ -172,9 +173,12 @@ extension DiskStorage {
   }
 
   func createDirectory() throws {
-    if !fileManager.fileExists(atPath: path) {
-      try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+    guard !fileManager.fileExists(atPath: path) else {
+      return
     }
+
+    try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true,
+                                    attributes: nil)
   }
 
   /**

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -14,7 +14,7 @@ final class DiskStorage {
   /// Configuration
   private let config: DiskConfig
   /// The computed path `directory+name`
-  private let path: String
+  let path: String
 
   // MARK: - Initialization
 
@@ -116,7 +116,7 @@ extension DiskStorage: StorageAware {
   }
 }
 
-fileprivate extension DiskStorage {
+extension DiskStorage {
   #if os(iOS) || os(tvOS)
   /**
    Data protection is used to store files in an encrypted format on disk and to decrypt them on demand.
@@ -136,9 +136,9 @@ fileprivate extension DiskStorage {
   }
 }
 
-fileprivate typealias ResourceObject = (url: Foundation.URL, resourceValues: [AnyHashable: Any])
+typealias ResourceObject = (url: Foundation.URL, resourceValues: [AnyHashable: Any])
 
-fileprivate extension DiskStorage {
+extension DiskStorage {
   /**
    Builds file name from the key.
    - Parameter key: Unique key to identify the object in the cache

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -52,11 +52,12 @@ extension DiskStorage: StorageAware {
     )
   }
 
-  func setObject<T: Codable>(_ object: T, forKey key: String) throws {
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+    let expiry = expiry ?? config.expiry
     let data = try DataSerializer.serialize(object: object)
     let filePath = makeFilePath(for: key)
     fileManager.createFile(atPath: filePath, contents: data, attributes: nil)
-    try fileManager.setAttributes([.modificationDate: config.expiry.date], ofItemAtPath: filePath)
+    try fileManager.setAttributes([.modificationDate: expiry.date], ofItemAtPath: filePath)
   }
 
   func removeObject(forKey key: String) throws {

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -52,7 +52,7 @@ extension DiskStorage: StorageAware {
     )
   }
 
-  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
     let expiry = expiry ?? config.expiry
     let data = try DataSerializer.serialize(object: object)
     let filePath = makeFilePath(for: key)

--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -24,9 +24,9 @@ extension HybridStorage: StorageAware {
     try diskStorage.removeObject(forKey: key)
   }
 
-  func setObject<T: Codable>(_ object: T, forKey key: String) throws {
-    memoryStorage.setObject(object, forKey: key)
-    try diskStorage.setObject(object, forKey: key)
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+    memoryStorage.setObject(object, forKey: key, expiry: expiry)
+    try diskStorage.setObject(object, forKey: key, expiry: expiry)
   }
 
   func removeAll() throws {

--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -24,7 +24,7 @@ extension HybridStorage: StorageAware {
     try diskStorage.removeObject(forKey: key)
   }
 
-  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
     memoryStorage.setObject(object, forKey: key, expiry: expiry)
     try diskStorage.setObject(object, forKey: key, expiry: expiry)
   }

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -36,7 +36,7 @@ extension MemoryStorage: StorageAware {
     keys.remove(key)
   }
 
-  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) {
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) {
     let capsule = Capsule(value: object, expiry: expiry ?? config.expiry)
     cache.setObject(capsule, forKey: key as NSString)
     keys.insert(key)

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -36,8 +36,8 @@ extension MemoryStorage: StorageAware {
     keys.remove(key)
   }
 
-  func setObject<T: Codable>(_ object: T, forKey key: String) {
-    let capsule = Capsule(value: object, expiry: config.expiry)
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) {
+    let capsule = Capsule(value: object, expiry: expiry ?? config.expiry)
     cache.setObject(capsule, forKey: key as NSString)
     keys.insert(key)
   }

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -55,7 +55,7 @@ extension MemoryStorage: StorageAware {
   }
 }
 
-fileprivate extension MemoryStorage {
+extension MemoryStorage {
   /**
    Removes the object from the cache if it's expired.
    - Parameter key: Unique key to identify the object in the cache

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -30,7 +30,7 @@ extension Storage: StorageAware {
     try internalStorage.removeObject(forKey: key)
   }
 
-  public func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+  public func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
     try internalStorage.setObject(object, forKey: key, expiry: expiry)
   }
 

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -30,8 +30,8 @@ extension Storage: StorageAware {
     try internalStorage.removeObject(forKey: key)
   }
 
-  public func setObject<T: Codable>(_ object: T, forKey key: String) throws {
-    try internalStorage.setObject(object, forKey: key)
+  public func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws {
+    try internalStorage.setObject(object, forKey: key, expiry: expiry)
   }
 
   public func removeAll() throws {

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -26,7 +26,7 @@ public protocol StorageAware {
    - Parameter key: Unique key to identify the object in the cache
    - Parameter object: Object that needs to be cached
    */
-  func setObject<T: Codable>(_ object: T, forKey key: String) throws
+  func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry?) throws
 
   /**
    Check if an object exist by the given key.

--- a/Tests/TestHelper.swift
+++ b/Tests/TestHelper.swift
@@ -7,10 +7,6 @@ import AppKit
 #endif
 
 struct TestHelper {
-  static var user: User {
-    return User(firstName: "John", lastName: "Snow")
-  }
-
   static func data(_ length : Int) -> Data {
     let buffer = [UInt8](repeating: 0, count: length)
     return Data(bytes: buffer)

--- a/Tests/iOS/Tests/DataStructures/CapsuleTests.swift
+++ b/Tests/iOS/Tests/DataStructures/CapsuleTests.swift
@@ -2,18 +2,18 @@ import XCTest
 @testable import Cache
 
 final class CapsuleTests: XCTestCase {
+  let testObject = User(firstName: "a", lastName: "b")
+
   func testExpiredWhenNotExpired() {
-    let object = TestHelper.user
     let date = Date(timeInterval: 100000, since: Date())
-    let capsule = Capsule(value: object, expiry: .date(date))
+    let capsule = Capsule(value: testObject, expiry: .date(date))
 
     XCTAssertFalse(capsule.isExpired)
   }
 
   func testExpiredWhenExpired() {
-    let object = TestHelper.user
     let date = Date(timeInterval: -100000, since: Date())
-    let capsule = Capsule(value: object, expiry: .date(date))
+    let capsule = Capsule(value: testObject, expiry: .date(date))
 
     XCTAssertTrue(capsule.isExpired)
   }

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+import SwiftHash
+@testable import Cache
+
+final class DiskStorageTests: XCTestCase {
+  private let key = "youknownothing"
+  private let testObject = User(firstName: "John", lastName: "Snow")
+  private let fileManager = FileManager()
+  private var storage: DiskStorage!
+  private let config = DiskConfig(name: "Floppy")
+
+  override func setUp() {
+    super.setUp()
+    storage = try! DiskStorage(config: config)
+  }
+
+  override func tearDown() {
+    try? fileManager.removeItem(atPath: storage.path)
+    super.tearDown()
+  }
+
+  func testInit() {
+    // Test that it creates cache directory
+    let fileExist = fileManager.fileExists(atPath: storage.path)
+    XCTAssertTrue(fileExist)
+
+    // Test that it returns the default maximum size of a cache
+    XCTAssertEqual(config.maxSize, 0)
+  }
+
+  /// Test that it returns the correct path
+  func testDefaultPath() {
+    let paths = NSSearchPathForDirectoriesInDomains(
+      .cachesDirectory, FileManager.SearchPathDomainMask.userDomainMask, true
+    )
+    let path = "\(paths.first!)/\(config.name.capitalized)"
+    XCTAssertEqual(storage.path, path)
+  }
+
+  /// Test that it returns the correct path
+  func testCustomPath() throws {
+    let url = try fileManager.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
+
+    let customConfig = DiskConfig(name: "CustomPath", directory: url)
+
+    storage = try DiskStorage(config: customConfig)
+
+    XCTAssertEqual(storage.path, url.absoluteString)
+  }
+
+  /// Test that it sets attributes
+  func testSetDirectoryAttributes() throws {
+    try storage.setObject(testObject, forKey: key)
+    try storage.setDirectoryAttributes([FileAttributeKey.immutable: true])
+    let attributes = try fileManager.attributesOfItem(atPath: storage.path)
+
+    XCTAssertTrue(attributes[FileAttributeKey.immutable] as? Bool == true)
+    try storage.setDirectoryAttributes([FileAttributeKey.immutable: false])
+  }
+
+  /// Test that it saves an object
+  func testsetObject() throws {
+    try storage.setObject(testObject, forKey: key)
+    let fileExist = fileManager.fileExists(atPath: storage.makeFilePath(for: key))
+    XCTAssertTrue(fileExist)
+  }
+
+  /// Test that
+  func testCacheEntry() throws {
+    // Returns nil if entry doesn't exist
+    var entry: Entry<User>?
+    do {
+      entry = try storage.entry(forKey: key)
+    } catch {}
+    XCTAssertNil(entry)
+
+    // Returns entry if object exists
+    try storage.setObject(testObject, forKey: key)
+    entry = try storage.entry(forKey: key)
+    let attributes = try fileManager.attributesOfItem(atPath: storage.makeFilePath(for: key))
+    let expiry = Expiry.date(attributes[FileAttributeKey.modificationDate] as! Date)
+
+    XCTAssertEqual(entry?.object.firstName, testObject.firstName)
+    XCTAssertEqual(entry?.object.lastName, testObject.lastName)
+    XCTAssertEqual(entry?.expiry.date, expiry.date)
+  }
+
+  /// Test that it resolves cached object
+  func testSetObject() throws {
+    try storage.setObject(testObject, forKey: key)
+    let cachedObject: User? = try storage.object(forKey: key)
+
+    XCTAssertEqual(cachedObject?.firstName, testObject.firstName)
+    XCTAssertEqual(cachedObject?.lastName, testObject.lastName)
+  }
+
+  /// Test that it removes cached object
+  func testRemoveObject() throws {
+    try storage.setObject(testObject, forKey: key)
+    try storage.removeObject(forKey: key)
+    let fileExist = fileManager.fileExists(atPath: storage.makeFilePath(for: key))
+    XCTAssertFalse(fileExist)
+  }
+
+  /// Test that it removes expired object
+  func testRemoveObjectIfExpiredWhenExpired() throws {
+    let expiry: Expiry = .date(Date().addingTimeInterval(-100000))
+    try storage.setObject(testObject, forKey: key, expiry: expiry)
+    try storage.removeObjectIfExpired(forKey: key)
+    var cachedObject: User?
+    do {
+      cachedObject = try storage.object(forKey: key)
+    } catch {}
+
+    XCTAssertNil(cachedObject)
+  }
+
+  /// Test that it doesn't remove not expired object
+  func testRemoveObjectIfExpiredWhenNotExpired() throws {
+    try storage.setObject(testObject, forKey: key)
+    try storage.removeObjectIfExpired(forKey: key)
+    let cachedObject: User? = try storage.object(forKey: key)
+    XCTAssertNotNil(cachedObject)
+  }
+
+  /// Test that it clears cache directory
+  func testClear() throws {
+    try storage.setObject(testObject, forKey: key)
+    try storage.removeAll()
+    let fileExist = fileManager.fileExists(atPath: storage.path)
+    XCTAssertFalse(fileExist)
+  }
+
+  /// Test that it clears cache files, but keeps root directory
+  func testCreateDirectory() throws {
+    try storage.removeAll()
+    XCTAssertFalse(fileManager.fileExists(atPath: storage.path))
+
+    try storage.createDirectory()
+    XCTAssertTrue(fileManager.fileExists(atPath: storage.path))
+  }
+
+  /// Test that it removes expired objects
+  func testClearExpired() throws {
+    let expiry1: Expiry = .date(Date().addingTimeInterval(-100000))
+    let expiry2: Expiry = .date(Date().addingTimeInterval(100000))
+    let key1 = "item1"
+    let key2 = "item2"
+    try storage.setObject(testObject, forKey: key1, expiry: expiry1)
+    try storage.setObject(testObject, forKey: key2, expiry: expiry2)
+    try storage.removeExpiredObjects()
+    var object1: User?
+    let object2: User? = try storage.object(forKey: key2)
+
+    do {
+      object1 = try storage.object(forKey: key1)
+    } catch {}
+
+    XCTAssertNil(object1)
+    XCTAssertNotNil(object2)
+  }
+
+  /// Test that it returns a correct file name
+  func testMakeFileName() {
+    XCTAssertEqual(storage.makeFileName(for: key), MD5(key))
+  }
+
+  /// Test that it returns a correct file path
+  func testMakeFilePath() {
+    let filePath = "\(storage.path)/\(storage.makeFileName(for: key))"
+    XCTAssertEqual(storage.makeFilePath(for: key), filePath)
+  }
+}
+

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -46,11 +46,14 @@ final class DiskStorageTests: XCTestCase {
       create: true
     )
 
-    let customConfig = DiskConfig(name: "CustomPath", directory: url)
+    let customConfig = DiskConfig(name: "SSD", directory: url)
 
     storage = try DiskStorage(config: customConfig)
 
-    XCTAssertEqual(storage.path, url.absoluteString)
+    XCTAssertEqual(
+      storage.path,
+      url.appendingPathComponent("SSD", isDirectory: true).path
+    )
   }
 
   /// Test that it sets attributes

--- a/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 final class MemoryStorageTests: XCTestCase {
   private let key = "youknownothing"
-  private let object = TestHelper.user
+  private let testObject = User(firstName: "John", lastName: "Snow")
   private var storage: MemoryStorage!
+  private let config = MemoryConfig(expiry: .never, countLimit: 10, totalCostLimit: 10)
 
   override func setUp() {
     super.setUp()
-    let config = MemoryConfig(expiry: .never, countLimit: 10, totalCostLimit: 10)
     storage = MemoryStorage(config: config)
   }
 
@@ -18,56 +18,49 @@ final class MemoryStorageTests: XCTestCase {
   }
 
   /// Test that it saves an object
-  func testAddObject() {
-    storage.setObject(object, forKey: key)
+  func testSetObject() {
+    storage.setObject(testObject, forKey: key)
     let cachedObject: User = try! storage.object(forKey: key)
     XCTAssertNotNil(cachedObject)
+    XCTAssertEqual(cachedObject.firstName, testObject.firstName)
+    XCTAssertEqual(cachedObject.lastName, testObject.lastName)
   }
 
   func testCacheEntry() {
     // Returns nil if entry doesn't exist
-    var entry: Entry<User> = try! storage.entry(forKey: key)
+    var entry = try? storage.entry(forKey: key) as Entry<User>
     XCTAssertNil(entry)
 
     // Returns entry if object exists
-    let expiry = Expiry.date(Date())
-    storage.setObject(object, forKey: key)
+    storage.setObject(testObject, forKey: key)
     entry = try! storage.entry(forKey: key)
 
-    XCTAssertEqual(entry.object.firstName, object.firstName)
-    XCTAssertEqual(entry.object.lastName, object.lastName)
-    XCTAssertEqual(entry.expiry.date, expiry.date)
-  }
-
-  /// Test that it resolves cached object
-  func testObject() {
-    storage.setObject(object, forKey: key)
-    let cachedObject: User = try! storage.object(forKey: key)
-    XCTAssertEqual(cachedObject.firstName, object.firstName)
-    XCTAssertEqual(cachedObject.lastName, object.lastName)
+    XCTAssertEqual(entry?.object.firstName, testObject.firstName)
+    XCTAssertEqual(entry?.object.lastName, testObject.lastName)
+    XCTAssertEqual(entry?.expiry.date, config.expiry.date)
   }
 
   /// Test that it removes cached object
   func testRemoveObject() {
-    storage.setObject(object, forKey: key)
+    storage.setObject(testObject, forKey: key)
     storage.removeObject(forKey: key)
-    let cachedObject: User = try! storage.object(forKey: key)
+    let cachedObject = try? storage.object(forKey: key) as User
     XCTAssertNil(cachedObject)
   }
 
   /// Test that it removes expired object
   func testRemoveObjectIfExpiredWhenExpired() {
-    let expiry: Expiry = .date(Date().addingTimeInterval(-100000))
-    storage.setObject(object, forKey: key)
+    let expiry: Expiry = .date(Date().addingTimeInterval(-10))
+    storage.setObject(testObject, forKey: key, expiry: expiry)
     storage.removeObjectIfExpired(forKey: key)
-    let cachedObject: User = try! storage.object(forKey: key)
+    let cachedObject = try? storage.object(forKey: key) as User
 
     XCTAssertNil(cachedObject)
   }
 
   /// Test that it doesn't remove not expired object
   func testRemoveObjectIfExpiredWhenNotExpired() {
-    storage.setObject(object, forKey: key)
+    storage.setObject(testObject, forKey: key)
     storage.removeObjectIfExpired(forKey: key)
     let cachedObject: User = try! storage.object(forKey: key)
 
@@ -76,23 +69,23 @@ final class MemoryStorageTests: XCTestCase {
 
   /// Test that it clears cache directory
   func testRemoveAll() {
-    storage.setObject(object, forKey: key)
+    storage.setObject(testObject, forKey: key)
     storage.removeAll()
-    let cachedObject: User = try! storage.object(forKey: key)
+    let cachedObject = try? storage.object(forKey: key) as User
     XCTAssertNil(cachedObject)
   }
 
   /// Test that it removes expired objects
   func testClearExpired() {
-    let expiry1: Expiry = .date(Date().addingTimeInterval(-100000))
-    let expiry2: Expiry = .date(Date().addingTimeInterval(100000))
+    let expiry1: Expiry = .date(Date().addingTimeInterval(-10))
+    let expiry2: Expiry = .date(Date().addingTimeInterval(10))
     let key1 = "item1"
     let key2 = "item2"
-    storage.setObject(object, forKey: key1)
-    storage.setObject(object, forKey: key2)
+    storage.setObject(testObject, forKey: key1, expiry: expiry1)
+    storage.setObject(testObject, forKey: key2, expiry: expiry2)
     storage.removeExpiredObjects()
-    let object1: User = try! storage.object(forKey: key1)
-    let object2: User = try! storage.object(forKey: key2)
+    let object1 = try? storage.object(forKey: key1) as User
+    let object2 = try! storage.object(forKey: key2) as User
 
     XCTAssertNil(object1)
     XCTAssertNotNil(object2)

--- a/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import Cache
+
+final class MemoryStorageTests: XCTestCase {
+  private let key = "youknownothing"
+  private let object = TestHelper.user
+  private var storage: MemoryStorage!
+
+  override func setUp() {
+    super.setUp()
+    let config = MemoryConfig(expiry: .never, countLimit: 10, totalCostLimit: 10)
+    storage = MemoryStorage(config: config)
+  }
+
+  override func tearDown() {
+    storage.removeAll()
+    super.tearDown()
+  }
+
+  /// Test that it saves an object
+  func testAddObject() {
+    storage.setObject(object, forKey: key)
+    let cachedObject: User = try! storage.object(forKey: key)
+    XCTAssertNotNil(cachedObject)
+  }
+
+  func testCacheEntry() {
+    // Returns nil if entry doesn't exist
+    var entry: Entry<User> = try! storage.entry(forKey: key)
+    XCTAssertNil(entry)
+
+    // Returns entry if object exists
+    let expiry = Expiry.date(Date())
+    storage.setObject(object, forKey: key)
+    entry = try! storage.entry(forKey: key)
+
+    XCTAssertEqual(entry.object.firstName, object.firstName)
+    XCTAssertEqual(entry.object.lastName, object.lastName)
+    XCTAssertEqual(entry.expiry.date, expiry.date)
+  }
+
+  /// Test that it resolves cached object
+  func testObject() {
+    storage.setObject(object, forKey: key)
+    let cachedObject: User = try! storage.object(forKey: key)
+    XCTAssertEqual(cachedObject.firstName, object.firstName)
+    XCTAssertEqual(cachedObject.lastName, object.lastName)
+  }
+
+  /// Test that it removes cached object
+  func testRemoveObject() {
+    storage.setObject(object, forKey: key)
+    storage.removeObject(forKey: key)
+    let cachedObject: User = try! storage.object(forKey: key)
+    XCTAssertNil(cachedObject)
+  }
+
+  /// Test that it removes expired object
+  func testRemoveObjectIfExpiredWhenExpired() {
+    let expiry: Expiry = .date(Date().addingTimeInterval(-100000))
+    storage.setObject(object, forKey: key)
+    storage.removeObjectIfExpired(forKey: key)
+    let cachedObject: User = try! storage.object(forKey: key)
+
+    XCTAssertNil(cachedObject)
+  }
+
+  /// Test that it doesn't remove not expired object
+  func testRemoveObjectIfExpiredWhenNotExpired() {
+    storage.setObject(object, forKey: key)
+    storage.removeObjectIfExpired(forKey: key)
+    let cachedObject: User = try! storage.object(forKey: key)
+
+    XCTAssertNotNil(cachedObject)
+  }
+
+  /// Test that it clears cache directory
+  func testRemoveAll() {
+    storage.setObject(object, forKey: key)
+    storage.removeAll()
+    let cachedObject: User = try! storage.object(forKey: key)
+    XCTAssertNil(cachedObject)
+  }
+
+  /// Test that it removes expired objects
+  func testClearExpired() {
+    let expiry1: Expiry = .date(Date().addingTimeInterval(-100000))
+    let expiry2: Expiry = .date(Date().addingTimeInterval(100000))
+    let key1 = "item1"
+    let key2 = "item2"
+    storage.setObject(object, forKey: key1)
+    storage.setObject(object, forKey: key2)
+    storage.removeExpiredObjects()
+    let object1: User = try! storage.object(forKey: key1)
+    let object2: User = try! storage.object(forKey: key2)
+
+    XCTAssertNil(object1)
+    XCTAssertNotNil(object2)
+  }
+}


### PR DESCRIPTION
- Add tests for MemoryStorage and DiskStorage
- DiskStorage now always creates subfolder based on `config.name`. This avoids `removeAll` to clear all data if user mistakenly pastes `Document` folder 😱 
- This also adds `expiry` to each `setObject` for fine grain control