### PR TITLE
Add PrimitiveStorage

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		D2CF98831F69513800CE8F68 /* MemoryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF987B1F69513800CE8F68 /* MemoryStorageTests.swift */; };
 		D2CF98851F69598900CE8F68 /* PrimitiveStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98841F69598900CE8F68 /* PrimitiveStorage.swift */; };
 		D2CF98871F695B8F00CE8F68 /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98861F695B8F00CE8F68 /* Types.swift */; };
+		D2CF98891F695F9400CE8F68 /* PrimitiveStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98881F695F9400CE8F68 /* PrimitiveStorageTests.swift */; };
 		D5291D1D1C2837DB00B702C9 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5DC59E01C20593E003BD79B /* Cache.framework */; };
 		D5291D6A1C283B5400B702C9 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5291D601C283B5300B702C9 /* Cache.framework */; };
 		D5291D851C283C7C00B702C9 /* TestHelper+OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291D811C283C7000B702C9 /* TestHelper+OSX.swift */; };
@@ -111,6 +112,7 @@
 		D2CF987B1F69513800CE8F68 /* MemoryStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryStorageTests.swift; sourceTree = "<group>"; };
 		D2CF98841F69598900CE8F68 /* PrimitiveStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimitiveStorage.swift; sourceTree = "<group>"; };
 		D2CF98861F695B8F00CE8F68 /* Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
+		D2CF98881F695F9400CE8F68 /* PrimitiveStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimitiveStorageTests.swift; sourceTree = "<group>"; };
 		D5291CDF1C28374800B702C9 /* TestHelper+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TestHelper+iOS.swift"; sourceTree = "<group>"; };
 		D5291D181C2837DB00B702C9 /* Cache-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5291D231C28380100B702C9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				D2CF98791F69513800CE8F68 /* DiskStorageTests.swift */,
 				D2CF987A1F69513800CE8F68 /* HybridStorageTests.swift */,
 				D2CF987B1F69513800CE8F68 /* MemoryStorageTests.swift */,
+				D2CF98881F695F9400CE8F68 /* PrimitiveStorageTests.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -758,6 +761,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2CF987E1F69513800CE8F68 /* ExpiryTests.swift in Sources */,
+				D2CF98891F695F9400CE8F68 /* PrimitiveStorageTests.swift in Sources */,
 				D2CF98821F69513800CE8F68 /* HybridStorageTests.swift in Sources */,
 				D2CF98831F69513800CE8F68 /* MemoryStorageTests.swift in Sources */,
 				D2CF987C1F69513800CE8F68 /* Date+ExtensionsTests.swift in Sources */,

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		D2CF98811F69513800CE8F68 /* DiskStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98791F69513800CE8F68 /* DiskStorageTests.swift */; };
 		D2CF98821F69513800CE8F68 /* HybridStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF987A1F69513800CE8F68 /* HybridStorageTests.swift */; };
 		D2CF98831F69513800CE8F68 /* MemoryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF987B1F69513800CE8F68 /* MemoryStorageTests.swift */; };
+		D2CF98851F69598900CE8F68 /* PrimitiveStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98841F69598900CE8F68 /* PrimitiveStorage.swift */; };
+		D2CF98871F695B8F00CE8F68 /* Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98861F695B8F00CE8F68 /* Types.swift */; };
 		D5291D1D1C2837DB00B702C9 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5DC59E01C20593E003BD79B /* Cache.framework */; };
 		D5291D6A1C283B5400B702C9 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5291D601C283B5300B702C9 /* Cache.framework */; };
 		D5291D851C283C7C00B702C9 /* TestHelper+OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291D811C283C7000B702C9 /* TestHelper+OSX.swift */; };
@@ -107,6 +109,8 @@
 		D2CF98791F69513800CE8F68 /* DiskStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskStorageTests.swift; sourceTree = "<group>"; };
 		D2CF987A1F69513800CE8F68 /* HybridStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HybridStorageTests.swift; sourceTree = "<group>"; };
 		D2CF987B1F69513800CE8F68 /* MemoryStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryStorageTests.swift; sourceTree = "<group>"; };
+		D2CF98841F69598900CE8F68 /* PrimitiveStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimitiveStorage.swift; sourceTree = "<group>"; };
+		D2CF98861F695B8F00CE8F68 /* Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
 		D5291CDF1C28374800B702C9 /* TestHelper+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TestHelper+iOS.swift"; sourceTree = "<group>"; };
 		D5291D181C2837DB00B702C9 /* Cache-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5291D231C28380100B702C9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -222,6 +226,7 @@
 				D2CF98571F694FFA00CE8F68 /* ImageWrapper.swift */,
 				D2CF98581F694FFA00CE8F68 /* PrimitiveWrapper.swift */,
 				D2CF98591F694FFA00CE8F68 /* StorageError.swift */,
+				D2CF98861F695B8F00CE8F68 /* Types.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -234,6 +239,7 @@
 				D2CF985D1F694FFA00CE8F68 /* MemoryStorage.swift */,
 				D2CF985E1F694FFA00CE8F68 /* Storage.swift */,
 				D2CF985F1F694FFA00CE8F68 /* StorageAware.swift */,
+				D2CF98841F69598900CE8F68 /* PrimitiveStorage.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -796,6 +802,7 @@
 				D2CF98681F694FFA00CE8F68 /* ImageWrapper.swift in Sources */,
 				D2CF98691F694FFA00CE8F68 /* PrimitiveWrapper.swift in Sources */,
 				D2CF986C1F694FFA00CE8F68 /* HybridStorage.swift in Sources */,
+				D2CF98871F695B8F00CE8F68 /* Types.swift in Sources */,
 				D2CF98621F694FFA00CE8F68 /* Date+Extensions.swift in Sources */,
 				D2CF98641F694FFA00CE8F68 /* DataSerializer.swift in Sources */,
 				D2CF986B1F694FFA00CE8F68 /* DiskStorage.swift in Sources */,
@@ -803,6 +810,7 @@
 				D2CF98601F694FFA00CE8F68 /* DiskConfig.swift in Sources */,
 				D2CF986D1F694FFA00CE8F68 /* MemoryStorage.swift in Sources */,
 				D2CF986F1F694FFA00CE8F68 /* StorageAware.swift in Sources */,
+				D2CF98851F69598900CE8F68 /* PrimitiveStorage.swift in Sources */,
 				D2CF98671F694FFA00CE8F68 /* Expiry.swift in Sources */,
 				D2CF986A1F694FFA00CE8F68 /* StorageError.swift in Sources */,
 				D5A138C11EB29BFA00881A20 /* UIImage+Extensions.swift in Sources */,

--- a/Source/Shared/Library/Entry.swift
+++ b/Source/Shared/Library/Entry.swift
@@ -6,4 +6,9 @@ public struct Entry<T: Codable> {
   public let object: T
   /// Expiry date
   public let expiry: Expiry
+
+  init(object: T, expiry: Expiry) {
+    self.object = object
+    self.expiry = expiry
+  }
 }

--- a/Source/Shared/Library/ImageWrapper.swift
+++ b/Source/Shared/Library/ImageWrapper.swift
@@ -15,7 +15,7 @@ struct ImageWrapper: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let data = try container.decode(Data.self, forKey: CodingKeys.image)
     guard let image = Image(data: data) else {
-      throw CacheError.decodingFailed
+      throw StorageError.decodingFailed
     }
 
     self.image = image
@@ -26,7 +26,7 @@ struct ImageWrapper: Codable {
     guard let data = image.hasAlpha
       ? UIImagePNGRepresentation(image)
       : UIImageJPEGRepresentation(image, 1.0) else {
-        throw CacheError.encodingFailed
+        throw StorageError.encodingFailed
     }
 
     try container.encode(data, forKey: CodingKeys.image)

--- a/Source/Shared/Library/ImageWrapper.swift
+++ b/Source/Shared/Library/ImageWrapper.swift
@@ -1,20 +1,20 @@
 import UIKit
 
 struct ImageWrapper: Codable {
-  let image: UIImage
+  let image: Image
 
   enum CodingKeys: String, CodingKey {
     case image
   }
 
-  public init(image: UIImage) {
+  public init(image: Image) {
     self.image = image
   }
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let data = try container.decode(Data.self, forKey: CodingKeys.image)
-    guard let image = UIImage(data: data) else {
+    guard let image = Image(data: data) else {
       throw CacheError.decodingFailed
     }
 

--- a/Source/Shared/Library/StorageError.swift
+++ b/Source/Shared/Library/StorageError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum CacheError: Error {
+public enum StorageError: Error {
   /// Object can be found
   case notFound
   /// Object is found, but casting to requested type failed

--- a/Source/Shared/Library/Types.swift
+++ b/Source/Shared/Library/Types.swift
@@ -1,0 +1,9 @@
+#if os(iOS) || os(tvOS)
+  import UIKit
+  public typealias Image = UIImage
+#elseif os(watchOS)
+
+#elseif os(OSX)
+  import AppKit
+  public typealias Image = NSImage
+#endif

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -42,7 +42,7 @@ extension DiskStorage: StorageAware {
     let object: T = try DataSerializer.deserialize(data: data)
 
     guard let date = attributes[.modificationDate] as? Date else {
-      throw CacheError.malformedFileAttributes
+      throw StorageError.malformedFileAttributes
     }
 
     return Entry(

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -19,11 +19,11 @@ final class MemoryStorage {
 extension MemoryStorage: StorageAware {
   func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
     guard let capsule = cache.object(forKey: key as NSString) else {
-      throw CacheError.notFound
+      throw StorageError.notFound
     }
 
     guard let object = capsule.object as? T else {
-      throw CacheError.typeNotMatch
+      throw StorageError.typeNotMatch
     }
 
     return Entry(object: object, expiry: Expiry.date(capsule.expiryDate))

--- a/Source/Shared/Storage/PrimitiveStorage.swift
+++ b/Source/Shared/Storage/PrimitiveStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftHash
 
-/// Allow storing primitive and image
+/// Allow storing primitive (Int, [Int], Set<Int>, Bool, ...)
 final class PrimitiveStorage {
   let internalStorage: StorageAware
 

--- a/Source/Shared/Storage/PrimitiveStorage.swift
+++ b/Source/Shared/Storage/PrimitiveStorage.swift
@@ -12,14 +12,7 @@ final class PrimitiveStorage {
 
 extension PrimitiveStorage: StorageAware {
   public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
-    guard isPrimitive(type: T.self) else {
-      return try internalStorage.entry(forKey: key) as Entry<T>
-    }
-
-    let wrapperEntry = try internalStorage.entry(forKey: key) as Entry<PrimitiveWrapper<T>>
-    let primitiveEntry = Entry(object: wrapperEntry.object.value,
-                               expiry: wrapperEntry.expiry)
-    return primitiveEntry
+    return try internalStorage.entry(forKey: key) as Entry<T>
   }
 
   public func removeObject(forKey key: String) throws {
@@ -28,13 +21,19 @@ extension PrimitiveStorage: StorageAware {
 
   public func setObject<T: Codable>(_ object: T, forKey key: String,
                                     expiry: Expiry? = nil) throws {
-    guard isPrimitive(type: T.self) else {
-      try internalStorage.setObject(object, forKey: key, expiry: expiry)
-      return
-    }
 
-    let wrapper = PrimitiveWrapper(value: object)
-    try internalStorage.setObject(wrapper, forKey: key, expiry: expiry)
+    do {
+      try internalStorage.setObject(object, forKey: key, expiry: expiry)
+    } catch let error as Swift.EncodingError {
+      // Top-level T encoded as number JSON fragment
+      switch error {
+      case .invalidValue(_, let context) where context.codingPath.isEmpty:
+        let wrapper = PrimitiveWrapper<T>(value: object)
+        try internalStorage.setObject(wrapper, forKey: key, expiry: expiry)
+      default:
+        break
+      }
+    }
   }
 
   public func removeAll() throws {
@@ -43,19 +42,5 @@ extension PrimitiveStorage: StorageAware {
 
   public func removeExpiredObjects() throws {
     try internalStorage.removeExpiredObjects()
-  }
-}
-
-extension PrimitiveStorage {
-  func isPrimitive<T>(type: T.Type) -> Bool {
-    let primitives: [Any.Type] = [
-      Bool.self, [Bool].self,
-      String.self, [String].self,
-      Int.self, [Int].self,
-      Float.self, [Float].self,
-      Double.self, [Double].self
-    ]
-
-    return primitives.contains(where: { $0.self == type.self })
   }
 }

--- a/Source/Shared/Storage/PrimitiveStorage.swift
+++ b/Source/Shared/Storage/PrimitiveStorage.swift
@@ -25,6 +25,15 @@ extension PrimitiveStorage: StorageAware {
       try internalStorage.setObject(object, forKey: key, expiry: expiry)
       return
     }
+
+    switch object {
+    case let object as Image:
+      let wrapper = ImageWrapper(image: object)
+      try internalStorage.setObject(wrapper, forKey: key, expiry: expiry)
+    default:
+      let wrapper = PrimitiveWrapper(value: object)
+      try internalStorage.setObject(wrapper, forKey: key, expiry: expiry)
+    }
   }
 
   public func removeAll() throws {
@@ -38,6 +47,15 @@ extension PrimitiveStorage: StorageAware {
 
 extension PrimitiveStorage {
   func isPrimitive<T>(type: T.Type) -> Bool {
-    return true
+    let primitives: [Any.Type] = [
+      Image.self,
+      Bool.self, [Bool].self,
+      String.self, [String].self,
+      Int.self, [Int].self,
+      Float.self, [Float].self,
+      Double.self, [Double].self
+    ]
+
+    return primitives.contains(where: { $0.self == type.self })
   }
 }

--- a/Source/Shared/Storage/PrimitiveStorage.swift
+++ b/Source/Shared/Storage/PrimitiveStorage.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftHash
+
+/// Allow storing primitive and image
+final class PrimitiveStorage {
+  let internalStorage: StorageAware
+
+  init(storage: StorageAware) {
+    self.internalStorage = storage
+  }
+}
+
+extension PrimitiveStorage: StorageAware {
+  public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
+    return try internalStorage.entry(forKey: key)
+  }
+
+  public func removeObject(forKey key: String) throws {
+    try internalStorage.removeObject(forKey: key)
+  }
+
+  public func setObject<T: Codable>(_ object: T, forKey key: String,
+                                    expiry: Expiry? = nil) throws {
+    guard isPrimitive(type: T.self) else {
+      try internalStorage.setObject(object, forKey: key, expiry: expiry)
+      return
+    }
+  }
+
+  public func removeAll() throws {
+    try internalStorage.removeAll()
+  }
+
+  public func removeExpiredObjects() throws {
+    try internalStorage.removeExpiredObjects()
+  }
+}
+
+extension PrimitiveStorage {
+  func isPrimitive<T>(type: T.Type) -> Bool {
+    return true
+  }
+}

--- a/Source/Shared/Storage/PrimitiveStorage.swift
+++ b/Source/Shared/Storage/PrimitiveStorage.swift
@@ -23,10 +23,10 @@ extension PrimitiveStorage: StorageAware {
                                    expiry: wrapperEntry.expiry)
         return primitiveEntry
       default:
-        return try internalStorage.entry(forKey: key) as Entry<T>
+        throw StorageError.typeNotMatch
       }
     } catch {
-      return try internalStorage.entry(forKey: key) as Entry<T>
+      throw StorageError.typeNotMatch
     }
   }
 

--- a/Source/Shared/Storage/PrimitiveStorage.swift
+++ b/Source/Shared/Storage/PrimitiveStorage.swift
@@ -23,10 +23,8 @@ extension PrimitiveStorage: StorageAware {
                                    expiry: wrapperEntry.expiry)
         return primitiveEntry
       default:
-        throw StorageError.typeNotMatch
+        throw error
       }
-    } catch {
-      throw StorageError.typeNotMatch
     }
   }
 
@@ -36,7 +34,6 @@ extension PrimitiveStorage: StorageAware {
 
   public func setObject<T: Codable>(_ object: T, forKey key: String,
                                     expiry: Expiry? = nil) throws {
-
     do {
       try internalStorage.setObject(object, forKey: key, expiry: expiry)
     } catch let error as Swift.EncodingError {

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -9,7 +9,7 @@ public class Storage {
   /// - Parameters:
   ///   - diskConfig: Configuration for disk storage
   ///   - memoryConfig: Optional. Pass confi if you want memory cache
-  /// - Throws: Throw CacheError if any.
+  /// - Throws: Throw StorageError if any.
   public required init(diskConfig: DiskConfig, memoryConfig: MemoryConfig? = nil) throws {
     let disk = try DiskStorage(config: diskConfig)
 

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -15,7 +15,7 @@ final class DiskStorageTests: XCTestCase {
   }
 
   override func tearDown() {
-    try? fileManager.removeItem(atPath: storage.path)
+    try? storage.removeAll()
     super.tearDown()
   }
 

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -53,6 +53,29 @@ final class PrimitiveStorageTests: XCTestCase {
     XCTAssertEqual(try storage.object(forKey: "array of doubles"), doubles)
   }
 
+  func testWithSet() throws {
+    let set = Set<Int>(arrayLiteral: 1, 2, 3)
+    try storage.setObject(set, forKey: "set")
+    XCTAssertEqual(try storage.object(forKey: "set") as Set<Int>, set)
+  }
+
+  func testWithSimpleDictionary() throws {
+    let dict: [String: Int] = [
+      "key1": 1,
+      "key2": 2
+    ]
+
+    try then("can't save dictionary") {
+      do {
+        try storage.setObject(dict, forKey: "dict")
+        let cachedObject = try storage.object(forKey: "key") as [String: Int]
+        XCTAssertEqual(cachedObject, dict)
+      } catch {
+        XCTAssertTrue(error.localizedDescription.contains("no such file"))
+      }
+    }
+  }
+
   func testSameKey() throws {
     let user = User(firstName: "John", lastName: "Snow")
     let key = "keyMadeOfDragonGlass"
@@ -80,6 +103,17 @@ final class PrimitiveStorageTests: XCTestCase {
     try then("Casting to float or double is the same") {
       XCTAssertEqual(try storage.object(forKey: key) as Float, 10.5)
       XCTAssertEqual(try storage.object(forKey: key) as Double, 10.5)
+    }
+  }
+
+  func testCastingToAnotherType() throws {
+    try storage.setObject("Hello", forKey: "string")
+
+    do {
+      let cachedObject = try storage.object(forKey: "string") as Int
+      XCTAssertEqual(cachedObject, 10)
+    } catch {
+      XCTAssertTrue(error is DecodingError)
     }
   }
 }

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -67,7 +67,7 @@ final class PrimitiveStorageTests: XCTestCase {
 
 
     try storage.setObject(dict, forKey: "dict")
-    let cachedObject = try storage.object(forKey: "key") as [String: Int]
+    let cachedObject = try storage.object(forKey: "dict") as [String: Int]
     XCTAssertEqual(cachedObject, dict)
   }
 

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -65,15 +65,20 @@ final class PrimitiveStorageTests: XCTestCase {
       "key2": 2
     ]
 
-    try then("can't save dictionary") {
-      do {
-        try storage.setObject(dict, forKey: "dict")
-        let cachedObject = try storage.object(forKey: "key") as [String: Int]
-        XCTAssertEqual(cachedObject, dict)
-      } catch {
-        XCTAssertTrue(error.localizedDescription.contains("no such file"))
-      }
-    }
+
+    try storage.setObject(dict, forKey: "dict")
+    let cachedObject = try storage.object(forKey: "key") as [String: Int]
+    XCTAssertEqual(cachedObject, dict)
+  }
+
+  func testWithComplexDictionary() {
+    let _: [String: Any] = [
+      "key1": 1,
+      "key2": 2
+    ]
+
+    // fatal error: Dictionary<String, Any> does not conform to Encodable because Any does not conform to Encodable
+    // try storage.setObject(dict, forKey: "dict")
   }
 
   func testSameKey() throws {

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -65,4 +65,14 @@ final class PrimitiveStorageTests: XCTestCase {
     try storage.setObject(doubles, forKey: "array of doubles")
     XCTAssertEqual(try storage.object(forKey: "array of doubles"), doubles)
   }
+
+  func testSameKey() throws {
+    let user = User(firstName: "John", lastName: "Snow")
+    let key = "keyMadeOfDragonGlass"
+    try storage.setObject(user, forKey: key)
+    try storage.setObject("Dragonstone", forKey: key)
+
+    XCTAssertNil(try? storage.object(forKey: key) as User)
+    XCTAssertNotNil(try storage.object(forKey: key) as String)
+  }
 }

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -17,19 +17,6 @@ final class PrimitiveStorageTests: XCTestCase {
     super.tearDown()
   }
 
-  func testPrimitiveCheck() {
-    XCTAssertTrue(storage.isPrimitive(type: Bool.self))
-    XCTAssertTrue(storage.isPrimitive(type: [Bool].self))
-    XCTAssertTrue(storage.isPrimitive(type: String.self))
-    XCTAssertTrue(storage.isPrimitive(type: [String].self))
-    XCTAssertTrue(storage.isPrimitive(type: Int.self))
-    XCTAssertTrue(storage.isPrimitive(type: [Int].self))
-    XCTAssertTrue(storage.isPrimitive(type: Float.self))
-    XCTAssertTrue(storage.isPrimitive(type: [Float].self))
-    XCTAssertTrue(storage.isPrimitive(type: Double.self))
-    XCTAssertTrue(storage.isPrimitive(type: [Double].self))
-  }
-
   func testSetPrimitive() throws {
     try storage.setObject(true, forKey: "bool")
     XCTAssertEqual(try storage.object(forKey: "bool"), true)

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Cache
+
+final class PrimitiveStorageTests: XCTestCase {
+  private var storage: PrimitiveStorage!
+
+  override func setUp() {
+    super.setUp()
+    let memory = MemoryStorage(config: MemoryConfig())
+    let disk = try! DiskStorage(config: DiskConfig(name: "Floppy"))
+    let hybrid = HybridStorage(memoryStorage: memory, diskStorage: disk)
+    storage = PrimitiveStorage(storage: hybrid)
+  }
+
+  override func tearDown() {
+    try? storage.removeAll()
+    super.tearDown()
+  }
+
+  func testPrimitiveCheck() {
+    XCTAssertTrue(storage.isPrimitive(type: UIImage.self))
+    XCTAssertTrue(storage.isPrimitive(type: Bool.self))
+    XCTAssertTrue(storage.isPrimitive(type: [Bool].self))
+    XCTAssertTrue(storage.isPrimitive(type: String.self))
+    XCTAssertTrue(storage.isPrimitive(type: [String].self))
+    XCTAssertTrue(storage.isPrimitive(type: Int.self))
+    XCTAssertTrue(storage.isPrimitive(type: [Int].self))
+    XCTAssertTrue(storage.isPrimitive(type: Float.self))
+    XCTAssertTrue(storage.isPrimitive(type: [Float].self))
+    XCTAssertTrue(storage.isPrimitive(type: Double.self))
+    XCTAssertTrue(storage.isPrimitive(type: [Double].self))
+  }
+}

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -18,7 +18,6 @@ final class PrimitiveStorageTests: XCTestCase {
   }
 
   func testPrimitiveCheck() {
-    XCTAssertTrue(storage.isPrimitive(type: UIImage.self))
     XCTAssertTrue(storage.isPrimitive(type: Bool.self))
     XCTAssertTrue(storage.isPrimitive(type: [Bool].self))
     XCTAssertTrue(storage.isPrimitive(type: String.self))
@@ -29,5 +28,41 @@ final class PrimitiveStorageTests: XCTestCase {
     XCTAssertTrue(storage.isPrimitive(type: [Float].self))
     XCTAssertTrue(storage.isPrimitive(type: Double.self))
     XCTAssertTrue(storage.isPrimitive(type: [Double].self))
+  }
+
+  func testSetPrimitive() throws {
+    try storage.setObject(true, forKey: "bool")
+    XCTAssertEqual(try storage.object(forKey: "bool"), true)
+
+    try storage.setObject([true, false, true], forKey: "array of bools")
+    XCTAssertEqual(try storage.object(forKey: "array of bools"), [true, false, true])
+
+    try storage.setObject("one", forKey: "string")
+    XCTAssertEqual(try storage.object(forKey: "string"), "one")
+
+    try storage.setObject(["one", "two", "three"], forKey: "array of strings")
+    XCTAssertEqual(try storage.object(forKey: "array of strings"), ["one", "two", "three"])
+
+    try storage.setObject(10, forKey: "int")
+    XCTAssertEqual(try storage.object(forKey: "int"), 10)
+
+    try storage.setObject([1, 2, 3], forKey: "array of ints")
+    XCTAssertEqual(try storage.object(forKey: "array of ints"), [1, 2, 3])
+
+    let float: Float = 1.1
+    try storage.setObject(float, forKey: "float")
+    XCTAssertEqual(try storage.object(forKey: "float"), float)
+
+    let floats: [Float] = [1.1, 1.2, 1.3]
+    try storage.setObject(floats, forKey: "array of floats")
+    XCTAssertEqual(try storage.object(forKey: "array of floats"), floats)
+
+    let double: Double = 1.1
+    try storage.setObject(double, forKey: "double")
+    XCTAssertEqual(try storage.object(forKey: "double"), double)
+
+    let doubles: [Double] = [1.1, 1.2, 1.3]
+    try storage.setObject(doubles, forKey: "array of doubles")
+    XCTAssertEqual(try storage.object(forKey: "array of doubles"), doubles)
   }
 }

--- a/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/PrimitiveStorageTests.swift
@@ -75,4 +75,24 @@ final class PrimitiveStorageTests: XCTestCase {
     XCTAssertNil(try? storage.object(forKey: key) as User)
     XCTAssertNotNil(try storage.object(forKey: key) as String)
   }
+
+  func testIntFloat() throws {
+    let key = "key"
+    try storage.setObject(10, forKey: key)
+
+    try then("Casting to int or float is the same") {
+      XCTAssertEqual(try storage.object(forKey: key) as Int, 10)
+      XCTAssertEqual(try storage.object(forKey: key) as Float, 10)
+    }
+  }
+
+  func testFloatDouble() throws {
+    let key = "key"
+    try storage.setObject(10.5, forKey: key)
+
+    try then("Casting to float or double is the same") {
+      XCTAssertEqual(try storage.object(forKey: key) as Float, 10.5)
+      XCTAssertEqual(try storage.object(forKey: key) as Double, 10.5)
+    }
+  }
 }


### PR DESCRIPTION
- By default, we can't use `JSONEncoder` and `JSONDecoder` for just primitive type. This checks and wrap them inside PrimitiveWrapper
- In the future, we may have our own things that conform to `Encoder` and `Decoder`