### PR TITLE
Add ReadSyncWriteAsyncStorage

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D280B6A71F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
 		D280B6A81F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
 		D280B6A91F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
+		D280B6AB1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6AA1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift */; };
 		D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291CDF1C28374800B702C9 /* TestHelper+iOS.swift */; };
 		D28C9BAF1F67EF8300C180C1 /* UIImage+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291DA01C28405900B702C9 /* UIImage+ExtensionsTests.swift */; };
 		D292DAF11F6A85F30060F614 /* SyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292DAF01F6A85F30060F614 /* SyncStorage.swift */; };
@@ -136,6 +137,7 @@
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadSyncWriteAsyncStorage.swift; sourceTree = "<group>"; };
+		D280B6AA1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadSyncWriteAsyncStorageTests.swift; sourceTree = "<group>"; };
 		D292DAF01F6A85F30060F614 /* SyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStorage.swift; sourceTree = "<group>"; };
 		D292DAF41F6A94000060F614 /* AsyncStorageAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStorageAware.swift; sourceTree = "<group>"; };
 		D292DAF81F6A962D0060F614 /* AsyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStorage.swift; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 				D2CF98881F695F9400CE8F68 /* PrimitiveStorageTests.swift */,
 				D292DB001F6AA06B0060F614 /* SyncStorageTests.swift */,
 				D292DB031F6AA0730060F614 /* AsyncStorageTests.swift */,
+				D280B6AA1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -833,6 +836,7 @@
 				D2CF98821F69513800CE8F68 /* HybridStorageTests.swift in Sources */,
 				D2CF98831F69513800CE8F68 /* MemoryStorageTests.swift in Sources */,
 				D2CF987C1F69513800CE8F68 /* Date+ExtensionsTests.swift in Sources */,
+				D280B6AB1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift in Sources */,
 				D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */,
 				D2CF98211F69427C00CE8F68 /* TestHelper.swift in Sources */,
 				D2CF987F1F69513800CE8F68 /* ImageWrapperTests.swift in Sources */,

--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		D21B669D1F6A724600125DE1 /* DiskConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF984D1F694FFA00CE8F68 /* DiskConfig.swift */; };
 		D21B669E1F6A724700125DE1 /* MemoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF984E1F694FFA00CE8F68 /* MemoryConfig.swift */; };
 		D21B66A11F6A747000125DE1 /* ImageWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98761F69513800CE8F68 /* ImageWrapperTests.swift */; };
+		D280B6A71F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
+		D280B6A81F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
+		D280B6A91F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
 		D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291CDF1C28374800B702C9 /* TestHelper+iOS.swift */; };
 		D28C9BAF1F67EF8300C180C1 /* UIImage+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291DA01C28405900B702C9 /* UIImage+ExtensionsTests.swift */; };
 		D292DAF11F6A85F30060F614 /* SyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292DAF01F6A85F30060F614 /* SyncStorage.swift */; };
@@ -132,6 +135,7 @@
 /* Begin PBXFileReference section */
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadSyncWriteAsyncStorage.swift; sourceTree = "<group>"; };
 		D292DAF01F6A85F30060F614 /* SyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStorage.swift; sourceTree = "<group>"; };
 		D292DAF41F6A94000060F614 /* AsyncStorageAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStorageAware.swift; sourceTree = "<group>"; };
 		D292DAF81F6A962D0060F614 /* AsyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStorage.swift; sourceTree = "<group>"; };
@@ -298,6 +302,7 @@
 				D292DAF01F6A85F30060F614 /* SyncStorage.swift */,
 				D292DAF41F6A94000060F614 /* AsyncStorageAware.swift */,
 				D292DAF81F6A962D0060F614 /* AsyncStorage.swift */,
+				D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -794,6 +799,7 @@
 				D292DAF31F6A85F30060F614 /* SyncStorage.swift in Sources */,
 				D21B668C1F6A723C00125DE1 /* Types.swift in Sources */,
 				D292DAFF1F6A970B0060F614 /* Result.swift in Sources */,
+				D280B6A91F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */,
 				D21B668A1F6A723C00125DE1 /* PrimitiveWrapper.swift in Sources */,
 				D21B669A1F6A724300125DE1 /* Date+Extensions.swift in Sources */,
 				D21B66891F6A723C00125DE1 /* ImageWrapper.swift in Sources */,
@@ -856,6 +862,7 @@
 				D292DAF21F6A85F30060F614 /* SyncStorage.swift in Sources */,
 				D21B66831F6A723C00125DE1 /* Types.swift in Sources */,
 				D292DAFE1F6A970B0060F614 /* Result.swift in Sources */,
+				D280B6A81F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */,
 				D21B66811F6A723C00125DE1 /* PrimitiveWrapper.swift in Sources */,
 				D21B66991F6A724200125DE1 /* Date+Extensions.swift in Sources */,
 				D21B66801F6A723C00125DE1 /* ImageWrapper.swift in Sources */,
@@ -900,6 +907,7 @@
 				D292DAF11F6A85F30060F614 /* SyncStorage.swift in Sources */,
 				D2CF98601F694FFA00CE8F68 /* DiskConfig.swift in Sources */,
 				D292DAFD1F6A970B0060F614 /* Result.swift in Sources */,
+				D280B6A71F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */,
 				D2CF986D1F694FFA00CE8F68 /* MemoryStorage.swift in Sources */,
 				D2CF986F1F694FFA00CE8F68 /* StorageAware.swift in Sources */,
 				D2CF98851F69598900CE8F68 /* PrimitiveStorage.swift in Sources */,

--- a/Source/Shared/Storage/ReadSyncWriteAsyncStorage.swift
+++ b/Source/Shared/Storage/ReadSyncWriteAsyncStorage.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Manipulate storage in a "read sync, write async" manner.
+final class ReadSyncWriteAsyncStorage {
+  let internalStorage: StorageAware
+  let concurrentQueue = DispatchQueue(label: "Cache.ReadSyncWriteAsyncStorage.Queue",
+                                      attributes: .concurrent)
+
+  init(storage: StorageAware) {
+    self.internalStorage = storage
+  }
+}
+
+extension ReadSyncWriteAsyncStorage {
+  public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
+    var entry: Entry<T>!
+    try concurrentQueue.sync {
+      entry = try internalStorage.entry(forKey: key) as Entry<T>
+    }
+
+    return entry
+  }
+
+  func object<T: Codable>(forKey key: String) throws -> T {
+    return try entry(forKey: key).object
+  }
+
+  func existsObject<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Bool {
+    do {
+      let _: T = try object(forKey: key)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  func removeObject(forKey key: String, completion: @escaping (Result<()>) -> Void) {
+    concurrentQueue.async(flags: .barrier) { [weak self] in
+      guard let `self` = self else {
+        completion(Result.error(StorageError.deallocated))
+        return
+      }
+
+      do {
+        try self.internalStorage.removeObject(forKey: key)
+        completion(Result.value(()))
+      } catch {
+        completion(Result.error(error))
+      }
+    }
+  }
+
+  func setObject<T: Codable>(_ object: T,
+                             forKey key: String,
+                             expiry: Expiry? = nil,
+                             completion: @escaping (Result<()>) -> Void) {
+    concurrentQueue.async(flags: .barrier) { [weak self] in
+      guard let `self` = self else {
+        completion(Result.error(StorageError.deallocated))
+        return
+      }
+
+      do {
+        try self.internalStorage.setObject(object, forKey: key, expiry: expiry)
+        completion(Result.value(()))
+      } catch {
+        completion(Result.error(error))
+      }
+    }
+  }
+
+  func removeAll(completion: @escaping (Result<()>) -> Void) {
+    concurrentQueue.async(flags: .barrier) { [weak self] in
+      guard let `self` = self else {
+        completion(Result.error(StorageError.deallocated))
+        return
+      }
+
+      do {
+        try self.internalStorage.removeAll()
+        completion(Result.value(()))
+      } catch {
+        completion(Result.error(error))
+      }
+    }
+  }
+
+  func removeExpiredObjects(completion: @escaping (Result<()>) -> Void) {
+    concurrentQueue.async(flags: .barrier) { [weak self] in
+      guard let `self` = self else {
+        completion(Result.error(StorageError.deallocated))
+        return
+      }
+
+      do {
+        try self.internalStorage.removeExpiredObjects()
+        completion(Result.value(()))
+      } catch {
+        completion(Result.error(error))
+      }
+    }
+  }
+}

--- a/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
@@ -41,7 +41,11 @@ final class ReadSyncWriteAsyncStorageTests: XCTestCase {
   }
 
   func testManyOperations() throws {
-    let iterationCount = 10_000
+    let iterationCount = 1_000
+
+    given("seed initial value") {
+      storage.setObject(0, forKey: "number", completion: { _ in })
+    }
 
     when("performs lots of operations") {
       DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in

--- a/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Cache
+
+final class ReadSyncWriteAsyncStorageTests: XCTestCase {
+  private var storage: ReadSyncWriteAsyncStorage!
+  let user = User(firstName: "John", lastName: "Snow")
+
+  override func setUp() {
+    super.setUp()
+    let memory = MemoryStorage(config: MemoryConfig())
+    let disk = try! DiskStorage(config: DiskConfig(name: "Floppy"))
+    let hybrid = HybridStorage(memoryStorage: memory, diskStorage: disk)
+    let primitive = PrimitiveStorage(storage: hybrid)
+    storage = ReadSyncWriteAsyncStorage(storage: primitive)
+  }
+
+  override func tearDown() {
+    storage.removeAll(completion: { _ in })
+    super.tearDown()
+  }
+
+  func testSetObject() throws {
+    storage.setObject(user, forKey: "user", completion: { _ in })
+    let cachedObject = try storage.object(forKey: "user") as User
+
+    XCTAssertEqual(cachedObject, user)
+  }
+
+  func testRemoveAll() throws {
+    given("add a lot of objects") {
+      Array(0..<100).forEach {
+        storage.setObject($0, forKey: "key-\($0)", completion: { _ in })
+      }
+    }
+
+    when("remove all") {
+      storage.removeAll(completion: { _ in })
+    }
+
+    try then("all are removed") {
+      XCTAssertFalse(try storage.existsObject(ofType: Int.self, forKey: "key-99"))
+    }
+  }
+
+  func testManyOperations() throws {
+    var number = 0
+    let iterationCount = 10_000
+
+    when("performs lots of operations") {
+      DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
+        number += 1
+        storage.setObject(number, forKey: "number", completion: { _ in })
+      }
+    }
+
+    try then("all operation must complete") {
+      let cachedObject = try storage.object(forKey: "number") as Int
+      XCTAssertEqual(cachedObject, iterationCount)
+    }
+  }
+}
+

--- a/Tests/iOS/Tests/Storage/SyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/SyncStorageTests.swift
@@ -8,9 +8,7 @@ final class SyncStorageTests: XCTestCase {
   override func setUp() {
     super.setUp()
     let memory = MemoryStorage(config: MemoryConfig())
-    let disk = try! DiskStorage(config: DiskConfig(name: "ASyncDisk"))
-    let hybrid = HybridStorage(memoryStorage: memory, diskStorage: disk)
-    let primitive = PrimitiveStorage(storage: hybrid)
+    let primitive = PrimitiveStorage(storage: memory)
     storage = SyncStorage(storage: primitive)
   }
 
@@ -44,16 +42,16 @@ final class SyncStorageTests: XCTestCase {
 
   func testManyOperations() {
     do {
-      var number = 0
       let iterationCount = 10_000
 
       when("performs lots of operations") {
         DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
           do {
+            var number = try storage.object(forKey: "number") as Int
             number += 1
             try storage.setObject(number, forKey: "number")
           } catch {
-            XCTFail()
+            XCTFail(error.localizedDescription)
           }
         }
       }

--- a/Tests/iOS/Tests/Storage/SyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/SyncStorageTests.swift
@@ -40,22 +40,26 @@ final class SyncStorageTests: XCTestCase {
     }
   }
 
-  func testManyOperations() {
-    do {
-      let iterationCount = 10_000
+  func testManyOperations() throws {
+    let iterationCount = 1_000
 
-      when("performs lots of operations") {
-        DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
-          do {
-            var number = try storage.object(forKey: "number") as Int
-            number += 1
-            try storage.setObject(number, forKey: "number")
-          } catch {
-            XCTFail(error.localizedDescription)
-          }
+    try given("seed initial value") {
+      try storage.setObject(0, forKey: "number")
+    }
+
+    when("performs lots of operations") {
+      DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
+        do {
+          var number = try storage.object(forKey: "number") as Int
+          number += 1
+          try storage.setObject(number, forKey: "number")
+        } catch {
+          XCTFail(error.localizedDescription)
         }
       }
+    }
 
+    do {
       try then("all operation must complete") {
         let number = try storage.object(forKey: "number") as Int
         XCTAssertEqual(number, iterationCount)


### PR DESCRIPTION
- This is read sync, write async storage. It uses concurrent queue with `barrier`. This is suitable for when multiple reads are performed more often.
- There are some tests about concurrent operations that fail. Maybe need to refactor those tests @vadymmarkov 🤔 