### PR TITLE
Update Storage

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		D21B669D1F6A724600125DE1 /* DiskConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF984D1F694FFA00CE8F68 /* DiskConfig.swift */; };
 		D21B669E1F6A724700125DE1 /* MemoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF984E1F694FFA00CE8F68 /* MemoryConfig.swift */; };
 		D21B66A11F6A747000125DE1 /* ImageWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98761F69513800CE8F68 /* ImageWrapperTests.swift */; };
+		D236F31A1F6BEF73004EE01F /* StorgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D236F3191F6BEF73004EE01F /* StorgeTests.swift */; };
 		D280B6A71F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
 		D280B6A81F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
 		D280B6A91F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */; };
@@ -133,6 +134,7 @@
 /* Begin PBXFileReference section */
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D236F3191F6BEF73004EE01F /* StorgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorgeTests.swift; sourceTree = "<group>"; };
 		D280B6A61F6AC33D00BA59BE /* ReadSyncWriteAsyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadSyncWriteAsyncStorage.swift; sourceTree = "<group>"; };
 		D280B6AA1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadSyncWriteAsyncStorageTests.swift; sourceTree = "<group>"; };
 		D292DAF01F6A85F30060F614 /* SyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStorage.swift; sourceTree = "<group>"; };
@@ -343,6 +345,7 @@
 				D292DB001F6AA06B0060F614 /* SyncStorageTests.swift */,
 				D292DB031F6AA0730060F614 /* AsyncStorageTests.swift */,
 				D280B6AA1F6AC69B00BA59BE /* ReadSyncWriteAsyncStorageTests.swift */,
+				D236F3191F6BEF73004EE01F /* StorgeTests.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -840,6 +843,7 @@
 				D2CF98801F69513800CE8F68 /* TypeWrapperTests.swift in Sources */,
 				D2CF98241F69427C00CE8F68 /* User.swift in Sources */,
 				D2CF981E1F69427C00CE8F68 /* TestCase+Extensions.swift in Sources */,
+				D236F31A1F6BEF73004EE01F /* StorgeTests.swift in Sources */,
 				D292DB011F6AA06B0060F614 /* SyncStorageTests.swift in Sources */,
 				D2CF98811F69513800CE8F68 /* DiskStorageTests.swift in Sources */,
 			);

--- a/Source/Shared/Storage/AsyncStorage.swift
+++ b/Source/Shared/Storage/AsyncStorage.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Manipulate storage in a "all async" manner.
 /// The completion closure will be called when operation completes.
-final class AsyncStorage {
+public class AsyncStorage {
   let internalStorage: StorageAware
-  let serialQueue = DispatchQueue(label: "Cache.AsyncStorage.Queue")
+  public let serialQueue = DispatchQueue(label: "Cache.AsyncStorage.Queue")
 
   init(storage: StorageAware) {
     self.internalStorage = storage
@@ -12,7 +12,7 @@ final class AsyncStorage {
 }
 
 extension AsyncStorage: AsyncStorageAware {
-  func entry<T>(forKey key: String, completion: @escaping (Result<Entry<T>>) -> Void) {
+  public func entry<T>(forKey key: String, completion: @escaping (Result<Entry<T>>) -> Void) {
     serialQueue.async { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))
@@ -28,7 +28,7 @@ extension AsyncStorage: AsyncStorageAware {
     }
   }
 
-  func removeObject(forKey key: String, completion: @escaping (Result<()>) -> Void) {
+  public func removeObject(forKey key: String, completion: @escaping (Result<()>) -> Void) {
     serialQueue.async { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))
@@ -44,7 +44,7 @@ extension AsyncStorage: AsyncStorageAware {
     }
   }
 
-  func setObject<T: Codable>(_ object: T,
+  public func setObject<T: Codable>(_ object: T,
                              forKey key: String,
                              expiry: Expiry? = nil,
                              completion: @escaping (Result<()>) -> Void) {
@@ -63,7 +63,7 @@ extension AsyncStorage: AsyncStorageAware {
     }
   }
 
-  func removeAll(completion: @escaping (Result<()>) -> Void) {
+  public func removeAll(completion: @escaping (Result<()>) -> Void) {
     serialQueue.async { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))
@@ -79,7 +79,7 @@ extension AsyncStorage: AsyncStorageAware {
     }
   }
 
-  func removeExpiredObjects(completion: @escaping (Result<()>) -> Void) {
+  public func removeExpiredObjects(completion: @escaping (Result<()>) -> Void) {
     serialQueue.async { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))

--- a/Source/Shared/Storage/ReadSyncWriteAsyncStorage.swift
+++ b/Source/Shared/Storage/ReadSyncWriteAsyncStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Manipulate storage in a "read sync, write async" manner.
-final class ReadSyncWriteAsyncStorage {
+public class ReadSyncWriteAsyncStorage {
   let internalStorage: StorageAware
   let concurrentQueue = DispatchQueue(label: "Cache.ReadSyncWriteAsyncStorage.Queue",
                                       attributes: .concurrent)
@@ -21,11 +21,11 @@ extension ReadSyncWriteAsyncStorage {
     return entry
   }
 
-  func object<T: Codable>(forKey key: String) throws -> T {
+  public func object<T: Codable>(forKey key: String) throws -> T {
     return try entry(forKey: key).object
   }
 
-  func existsObject<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Bool {
+  public func existsObject<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Bool {
     do {
       let _: T = try object(forKey: key)
       return true
@@ -34,7 +34,7 @@ extension ReadSyncWriteAsyncStorage {
     }
   }
 
-  func removeObject(forKey key: String, completion: @escaping (Result<()>) -> Void) {
+  public func removeObject(forKey key: String, completion: @escaping (Result<()>) -> Void) {
     concurrentQueue.async(flags: .barrier) { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))
@@ -50,7 +50,7 @@ extension ReadSyncWriteAsyncStorage {
     }
   }
 
-  func setObject<T: Codable>(_ object: T,
+  public func setObject<T: Codable>(_ object: T,
                              forKey key: String,
                              expiry: Expiry? = nil,
                              completion: @escaping (Result<()>) -> Void) {
@@ -69,7 +69,7 @@ extension ReadSyncWriteAsyncStorage {
     }
   }
 
-  func removeAll(completion: @escaping (Result<()>) -> Void) {
+  public func removeAll(completion: @escaping (Result<()>) -> Void) {
     concurrentQueue.async(flags: .barrier) { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))
@@ -85,7 +85,7 @@ extension ReadSyncWriteAsyncStorage {
     }
   }
 
-  func removeExpiredObjects(completion: @escaping (Result<()>) -> Void) {
+  public func removeExpiredObjects(completion: @escaping (Result<()>) -> Void) {
     concurrentQueue.async(flags: .barrier) { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -11,13 +11,25 @@ public class Storage {
   ///   - memoryConfig: Optional. Pass confi if you want memory cache
   /// - Throws: Throw StorageError if any.
   public required init(diskConfig: DiskConfig, memoryConfig: MemoryConfig? = nil) throws {
+    let storage: StorageAware
     let disk = try DiskStorage(config: diskConfig)
 
     if let memoryConfig = memoryConfig {
       let memory = MemoryStorage(config: memoryConfig)
-      internalStorage = HybridStorage(memoryStorage: memory, diskStorage: disk)
+      storage = HybridStorage(memoryStorage: memory, diskStorage: disk)
     } else {
-      internalStorage = disk
+      storage = disk
     }
+
+    self.internalStorage = TypeWrapperStorage(storage: storage)
   }
+
+  /// Return all sync storage
+  public lazy var sync: StorageAware = SyncStorage(storage: self.internalStorage)
+
+  /// Return all async storage
+  public lazy var async: AsyncStorageAware = AsyncStorage(storage: self.internalStorage)
+
+  /// Return read sync, write async storage
+  public lazy var readSyncWriteAsync: ReadSyncWriteAsyncStorage = ReadSyncWriteAsyncStorage(storage: self.internalStorage)
 }

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Manage storage. Use memory storage if specified.
 public class Storage {
-  private let internalStorage: StorageAware
+  let internalStorage: StorageAware
 
   /// Initialize storage with configuration options.
   ///
@@ -25,10 +25,10 @@ public class Storage {
   }
 
   /// Return all sync storage
-  public lazy var sync: StorageAware = SyncStorage(storage: self.internalStorage)
+  public lazy var sync: SyncStorage = SyncStorage(storage: self.internalStorage)
 
   /// Return all async storage
-  public lazy var async: AsyncStorageAware = AsyncStorage(storage: self.internalStorage)
+  public lazy var async: AsyncStorage = AsyncStorage(storage: self.internalStorage)
 
   /// Return read sync, write async storage
   public lazy var readSyncWriteAsync: ReadSyncWriteAsyncStorage = ReadSyncWriteAsyncStorage(storage: self.internalStorage)

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -21,25 +21,3 @@ public class Storage {
     }
   }
 }
-
-extension Storage: StorageAware {
-  public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
-    return try internalStorage.entry(forKey: key)
-  }
-
-  public func removeObject(forKey key: String) throws {
-    try internalStorage.removeObject(forKey: key)
-  }
-
-  public func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
-    try internalStorage.setObject(object, forKey: key, expiry: expiry)
-  }
-
-  public func removeAll() throws {
-    try internalStorage.removeAll()
-  }
-
-  public func removeExpiredObjects() throws {
-    try internalStorage.removeExpiredObjects()
-  }
-}

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Manipulate storage in a "all sync" manner.
 /// Block the current queue until the operation completes.
-final class SyncStorage {
+public class SyncStorage {
   let internalStorage: StorageAware
   fileprivate let serialQueue = DispatchQueue(label: "Cache.SyncStorage.Queue")
 

--- a/Tests/Shared/TestCase+Extensions.swift
+++ b/Tests/Shared/TestCase+Extensions.swift
@@ -13,17 +13,3 @@ extension XCTestCase {
     try closure()
   }
 }
-
-extension XCTestCase {
-  func wait(for duration: TimeInterval) {
-    let waitExpectation = expectation(description: "Waiting")
-
-    let when = DispatchTime.now() + duration
-    DispatchQueue.main.asyncAfter(deadline: when) {
-      waitExpectation.fulfill()
-    }
-
-    // We use a buffer here to avoid flakiness with Timer on CI
-    waitForExpectations(timeout: duration + 0.5)
-  }
-}

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -61,27 +61,4 @@ final class AsyncStorageTests: XCTestCase {
 
     wait(for: [expectation], timeout: 1)
   }
-
-  func testManyOperations() {
-    var number = 0
-    let iterationCount = 10_000
-
-    when("performs lots of operations") {
-      DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
-        number += 1
-        storage.setObject(number, forKey: "number", completion: { _ in })
-      }
-    }
-
-    then("all operation must complete") {
-      storage.object(forKey: "number", completion: { (result: Result<Int>) in
-        switch result {
-        case .value(let cachedNumber):
-          XCTAssertEqual(cachedNumber, iterationCount)
-        default:
-          XCTFail()
-        }
-      })
-    }
-  }
 }

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -8,7 +8,7 @@ final class AsyncStorageTests: XCTestCase {
   override func setUp() {
     super.setUp()
     let memory = MemoryStorage(config: MemoryConfig())
-    let disk = try! DiskStorage(config: DiskConfig(name: "Floppy"))
+    let disk = try! DiskStorage(config: DiskConfig(name: "Async Disk"))
     let hybrid = HybridStorage(memoryStorage: memory, diskStorage: disk)
     let primitive = TypeWrapperStorage(storage: hybrid)
     storage = AsyncStorage(storage: primitive)

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -20,21 +20,24 @@ final class AsyncStorageTests: XCTestCase {
   }
 
   func testSetObject() throws {
+    let expectation = self.expectation(description: #function)
+
     storage.setObject(user, forKey: "user", completion: { _ in })
     storage.object(forKey: "user", completion: { (result: Result<User>) in
       switch result {
       case .value(let cachedUser):
         XCTAssertEqual(cachedUser, self.user)
+        expectation.fulfill()
       default:
         XCTFail()
       }
     })
 
-    wait(for: 0.1)
+    wait(for: [expectation], timeout: 1)
   }
 
-
   func testRemoveAll() {
+    let expectation = self.expectation(description: #function)
     given("add a lot of objects") {
       Array(0..<100).forEach {
         storage.setObject($0, forKey: "key-\($0)", completion: { _ in })
@@ -51,12 +54,12 @@ final class AsyncStorageTests: XCTestCase {
         case .value:
           XCTFail()
         default:
-          break
+          expectation.fulfill()
         }
       })
     }
 
-    wait(for: 0.1)
+    wait(for: [expectation], timeout: 1)
   }
 
   func testManyOperations() {

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -132,14 +132,22 @@ final class DiskStorageTests: XCTestCase {
   }
 
   /// Test that it clears cache directory
-  func testClear() {
-    do {
+  func testClear() throws {
+    try given("create some files inside folder so that it is not empty") {
       try storage.setObject(testObject, forKey: key)
-      try storage.removeAll()
+    }
+
+    when("call removeAll to remove the whole the folder") {
+      do {
+        try storage.removeAll()
+      } catch {
+        XCTFail(error.localizedDescription)
+      }
+    }
+
+    then("the folder should be deleted") {
       let fileExist = fileManager.fileExists(atPath: storage.path)
       XCTAssertFalse(fileExist)
-    } catch {
-      XCTFail(error.localizedDescription)
     }
   }
 

--- a/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
@@ -39,30 +39,5 @@ final class ReadSyncWriteAsyncStorageTests: XCTestCase {
       XCTAssertFalse(try storage.existsObject(ofType: Int.self, forKey: "key-99"))
     }
   }
-
-  func testManyOperations() throws {
-    let iterationCount = 1_000
-
-    given("seed initial value") {
-      storage.setObject(0, forKey: "number", completion: { _ in })
-    }
-
-    when("performs lots of operations") {
-      DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
-        do {
-          var number = try storage.object(forKey: "number") as Int
-          number += 1
-          storage.setObject(number, forKey: "number", completion: { _ in })
-        } catch {
-          XCTFail(error.localizedDescription)
-        }
-      }
-    }
-
-    try then("all operation must complete") {
-      let cachedObject = try storage.object(forKey: "number") as Int
-      XCTAssertEqual(cachedObject, iterationCount)
-    }
-  }
 }
 

--- a/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/ReadSyncWriteAsyncStorageTests.swift
@@ -59,8 +59,6 @@ final class ReadSyncWriteAsyncStorageTests: XCTestCase {
       }
     }
 
-    wait(for: 1)
-
     try then("all operation must complete") {
       let cachedObject = try storage.object(forKey: "number") as Int
       XCTAssertEqual(cachedObject, iterationCount)

--- a/Tests/iOS/Tests/Storage/StorgeTests.swift
+++ b/Tests/iOS/Tests/Storage/StorgeTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Cache
+
+final class StorageTests: XCTestCase {
+  private var interalStorage: StorageAware!
+  private var storage: Storage!
+  let user = User(firstName: "John", lastName: "Snow")
+
+  override func setUp() {
+    super.setUp()
+
+    storage = try! Storage(diskConfig: DiskConfig(name: "Thor"), memoryConfig: MemoryConfig())
+    interalStorage = storage.internalStorage
+  }
+
+  override func tearDown() {
+    try? interalStorage.removeAll()
+    super.tearDown()
+  }
+
+  func testSync() throws {
+    try storage.sync.setObject(user, forKey: "user")
+    let cachedObject = try storage.sync.object(forKey: "user") as User
+
+    XCTAssertEqual(cachedObject, user)
+  }
+
+  func testAsync() {
+    let expectation = self.expectation(description: #function)
+    storage.async.setObject(user, forKey: "user", completion: { _ in })
+
+    storage.async.object(forKey: "user", completion: { (result: Result<User>) in
+      switch result {
+      case .value(let cachedUser):
+        XCTAssertEqual(cachedUser, self.user)
+        expectation.fulfill()
+      default:
+        XCTFail()
+      }
+    })
+
+    wait(for: [expectation], timeout: 2)
+  }
+}
+
+

--- a/Tests/iOS/Tests/Storage/StorgeTests.swift
+++ b/Tests/iOS/Tests/Storage/StorgeTests.swift
@@ -39,7 +39,7 @@ final class StorageTests: XCTestCase {
       }
     })
 
-    wait(for: [expectation], timeout: 2)
+    wait(for: [expectation], timeout: 1)
   }
 }
 

--- a/Tests/iOS/Tests/Storage/SyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/SyncStorageTests.swift
@@ -39,33 +39,4 @@ final class SyncStorageTests: XCTestCase {
       XCTAssertFalse(try storage.existsObject(ofType: Int.self, forKey: "key-99"))
     }
   }
-
-  func testManyOperations() throws {
-    let iterationCount = 1_000
-
-    try given("seed initial value") {
-      try storage.setObject(0, forKey: "number")
-    }
-
-    when("performs lots of operations") {
-      DispatchQueue.concurrentPerform(iterations: iterationCount) { _ in
-        do {
-          var number = try storage.object(forKey: "number") as Int
-          number += 1
-          try storage.setObject(number, forKey: "number")
-        } catch {
-          XCTFail(error.localizedDescription)
-        }
-      }
-    }
-
-    do {
-      try then("all operation must complete") {
-        let number = try storage.object(forKey: "number") as Int
-        XCTAssertEqual(number, iterationCount)
-      }
-    } catch {
-      XCTFail(error.localizedDescription)
-    }
-  }
 }


### PR DESCRIPTION
- This adds 3 properties to Storage. So user has choices to use depending on their needs

```swift
let syncStorage = Storage(diskConfig: ..., memoryConfig: ...).sync
let asyncStorage = Storage(diskConfig: ..., memoryConfig: ...).async
let syncAndAsyncStorage = Storage(diskConfig: ..., memoryConfig: ...).readSyncWriteAsync
```
- Also remove some tests for concurrency temporarily.
- Fix tests to use `expectation` rather than `wait(for: seconds)`