### PR TITLE
Add typeOf parameter

### DIFF
--- a/Source/Shared/Storage/AsyncStorage.swift
+++ b/Source/Shared/Storage/AsyncStorage.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Manipulate storage in a "all async" manner.
 /// The completion closure will be called when operation completes.
 public class AsyncStorage {
-  let internalStorage: StorageAware
+  private let internalStorage: StorageAware
   public let serialQueue: DispatchQueue
 
   init(storage: StorageAware, serialQueue: DispatchQueue) {

--- a/Source/Shared/Storage/AsyncStorage.swift
+++ b/Source/Shared/Storage/AsyncStorage.swift
@@ -13,7 +13,7 @@ public class AsyncStorage {
 }
 
 extension AsyncStorage: AsyncStorageAware {
-  public func entry<T>(forKey key: String, completion: @escaping (Result<Entry<T>>) -> Void) {
+  public func entry<T>(ofType type: T.Type, forKey key: String, completion: @escaping (Result<Entry<T>>) -> Void) {
     serialQueue.async { [weak self] in
       guard let `self` = self else {
         completion(Result.error(StorageError.deallocated))
@@ -21,7 +21,7 @@ extension AsyncStorage: AsyncStorageAware {
       }
 
       do {
-        let anEntry = try self.internalStorage.entry(forKey: key) as Entry<T>
+        let anEntry = try self.internalStorage.entry(ofType: type, forKey: key)
         completion(Result.value(anEntry))
       } catch {
         completion(Result.error(error))

--- a/Source/Shared/Storage/AsyncStorageAware.swift
+++ b/Source/Shared/Storage/AsyncStorageAware.swift
@@ -10,14 +10,14 @@ public protocol AsyncStorageAware: class {
    - Parameter key: Unique key to identify the object in the cache.
    - Parameter completion: Triggered until the operation completes.
    */
-  func object<T: Codable>(forKey key: String, completion: @escaping (Result<T>) -> Void)
+  func object<T: Codable>(ofType type: T.Type, forKey key: String, completion: @escaping (Result<T>) -> Void)
 
   /**
    Get cache entry which includes object with metadata.
    - Parameter key: Unique key to identify the object in the cache
    - Parameter completion: Triggered until the operation completes.
    */
-  func entry<T>(forKey key: String, completion: @escaping (Result<Entry<T>>) -> Void)
+  func entry<T>(ofType type: T.Type, forKey key: String, completion: @escaping (Result<Entry<T>>) -> Void)
 
   /**
    Removes the object by the given key.
@@ -61,8 +61,8 @@ public protocol AsyncStorageAware: class {
 }
 
 public extension AsyncStorageAware {
-  func object<T: Codable>(forKey key: String, completion: @escaping (Result<T>) -> Void) {
-    entry(forKey: key, completion: { (result: Result<Entry<T>>) in
+  func object<T: Codable>(ofType type: T.Type, forKey key: String, completion: @escaping (Result<T>) -> Void) {
+    entry(ofType: type, forKey: key, completion: { (result: Result<Entry<T>>) in
       completion(result.map({ entry in
         return entry.object
       }))
@@ -72,7 +72,7 @@ public extension AsyncStorageAware {
   func existsObject<T: Codable>(ofType type: T.Type,
                                 forKey key: String,
                                 completion: @escaping (Result<Bool>) -> Void) {
-    object(forKey: key, completion: { (result: Result<T>) in
+    object(ofType: type, forKey: key, completion: { (result: Result<T>) in
       completion(result.map({ _ in
         return true
       }))

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -35,7 +35,7 @@ final class DiskStorage {
 }
 
 extension DiskStorage: StorageAware {
-  func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
+  func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
     let filePath = makeFilePath(for: key)
     let data = try Data(contentsOf: URL(fileURLWithPath: filePath))
     let attributes = try fileManager.attributesOfItem(atPath: filePath)

--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -12,11 +12,11 @@ class HybridStorage {
 }
 
 extension HybridStorage: StorageAware {
-  func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
+  func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
     do {
-      return try memoryStorage.entry(forKey: key)
+      return try memoryStorage.entry(ofType: type, forKey: key)
     } catch {
-      let entry = try diskStorage.entry(forKey: key) as Entry<T>
+      let entry = try diskStorage.entry(ofType: type, forKey: key)
       // set back to memoryStorage
       memoryStorage.setObject(entry.object, forKey: key)
       return entry

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -17,7 +17,7 @@ final class MemoryStorage {
 }
 
 extension MemoryStorage: StorageAware {
-  func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
+  func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
     guard let capsule = cache.object(forKey: key as NSString) else {
       throw StorageError.notFound
     }

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -42,8 +42,8 @@ public class Storage {
 }
 
 extension Storage: StorageAware {
-  public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
-    return try sync.entry(forKey: key) as Entry<T>
+  public func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
+    return try sync.entry(ofType: type, forKey: key)
   }
 
   public func removeObject(forKey key: String) throws {

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -7,14 +7,14 @@ public protocol StorageAware {
    - Parameter key: Unique key to identify the object in the cache
    - Returns: Cached object or nil if not found
    */
-  func object<T: Codable>(forKey key: String) throws -> T
+  func object<T: Codable>(ofType type: T.Type, forKey key: String) throws -> T
 
   /**
    Get cache entry which includes object with metadata.
    - Parameter key: Unique key to identify the object in the cache
    - Returns: Object wrapper with metadata or nil if not found
    */
-  func entry<T: Codable>(forKey key: String) throws -> Entry<T>
+  func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T>
 
   /**
    Removes the object by the given key.
@@ -48,13 +48,13 @@ public protocol StorageAware {
 }
 
 public extension StorageAware {
-  func object<T: Codable>(forKey key: String) throws -> T {
-    return try entry(forKey: key).object
+  func object<T: Codable>(ofType type: T.Type, forKey key: String) throws -> T {
+    return try entry(ofType: type, forKey: key).object
   }
 
   func existsObject<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Bool {
     do {
-      let _: T = try object(forKey: key)
+      let _: T = try object(ofType: type, forKey: key)
       return true
     } catch {
       return false

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -13,10 +13,10 @@ public class SyncStorage {
 }
 
 extension SyncStorage: StorageAware {
-  public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
+  public func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
     var entry: Entry<T>!
     try serialQueue.sync {
-      entry = try internalStorage.entry(forKey: key) as Entry<T>
+      entry = try internalStorage.entry(ofType: type, forKey: key)
     }
 
     return entry

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Manipulate storage in a "all sync" manner.
 /// Block the current queue until the operation completes.
 public class SyncStorage {
-  let internalStorage: StorageAware
+  private let internalStorage: StorageAware
   fileprivate let serialQueue: DispatchQueue
 
   init(storage: StorageAware, serialQueue: DispatchQueue) {

--- a/Source/Shared/Storage/TypeWrapperStorage.swift
+++ b/Source/Shared/Storage/TypeWrapperStorage.swift
@@ -12,8 +12,8 @@ final class TypeWrapperStorage {
 }
 
 extension TypeWrapperStorage: StorageAware {
-  public func entry<T: Codable>(forKey key: String) throws -> Entry<T> {
-    let wrapperEntry = try internalStorage.entry(forKey: key) as Entry<TypeWrapper<T>>
+  public func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
+    let wrapperEntry = try internalStorage.entry(ofType: TypeWrapper<T>.self, forKey: key)
     return Entry(object: wrapperEntry.object.object, expiry: wrapperEntry.expiry)
   }
 

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -23,7 +23,7 @@ final class AsyncStorageTests: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     storage.setObject(user, forKey: "user", completion: { _ in })
-    storage.object(forKey: "user", completion: { (result: Result<User>) in
+    storage.object(ofType: User.self, forKey: "user", completion: { result in
       switch result {
       case .value(let cachedUser):
         XCTAssertEqual(cachedUser, self.user)

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -78,13 +78,13 @@ final class DiskStorageTests: XCTestCase {
     // Returns nil if entry doesn't exist
     var entry: Entry<User>?
     do {
-      entry = try storage.entry(forKey: key)
+      entry = try storage.entry(ofType: User.self, forKey: key)
     } catch {}
     XCTAssertNil(entry)
 
     // Returns entry if object exists
     try storage.setObject(testObject, forKey: key)
-    entry = try storage.entry(forKey: key)
+    entry = try storage.entry(ofType: User.self, forKey: key)
     let attributes = try fileManager.attributesOfItem(atPath: storage.makeFilePath(for: key))
     let expiry = Expiry.date(attributes[FileAttributeKey.modificationDate] as! Date)
 
@@ -96,7 +96,7 @@ final class DiskStorageTests: XCTestCase {
   /// Test that it resolves cached object
   func testSetObject() throws {
     try storage.setObject(testObject, forKey: key)
-    let cachedObject: User? = try storage.object(forKey: key)
+    let cachedObject: User? = try storage.object(ofType: User.self, forKey: key)
 
     XCTAssertEqual(cachedObject?.firstName, testObject.firstName)
     XCTAssertEqual(cachedObject?.lastName, testObject.lastName)
@@ -117,7 +117,7 @@ final class DiskStorageTests: XCTestCase {
     try storage.removeObjectIfExpired(forKey: key)
     var cachedObject: User?
     do {
-      cachedObject = try storage.object(forKey: key)
+      cachedObject = try storage.object(ofType: User.self, forKey: key)
     } catch {}
 
     XCTAssertNil(cachedObject)
@@ -127,7 +127,7 @@ final class DiskStorageTests: XCTestCase {
   func testRemoveObjectIfExpiredWhenNotExpired() throws {
     try storage.setObject(testObject, forKey: key)
     try storage.removeObjectIfExpired(forKey: key)
-    let cachedObject: User? = try storage.object(forKey: key)
+    let cachedObject: User? = try storage.object(ofType: User.self, forKey: key)
     XCTAssertNotNil(cachedObject)
   }
 
@@ -174,10 +174,10 @@ final class DiskStorageTests: XCTestCase {
     try storage.setObject(testObject, forKey: key2, expiry: expiry2)
     try storage.removeExpiredObjects()
     var object1: User?
-    let object2: User? = try storage.object(forKey: key2)
+    let object2 = try storage.object(ofType: User.self, forKey: key2)
 
     do {
-      object1 = try storage.object(forKey: key1)
+      object1 = try storage.object(ofType: User.self, forKey: key1)
     } catch {}
 
     XCTAssertNil(object1)

--- a/Tests/iOS/Tests/Storage/HybridStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/HybridStorageTests.swift
@@ -25,17 +25,17 @@ final class HybridStorageTests: XCTestCase {
   func testSetObject() throws {
     try when("set to storage") {
       try storage.setObject(testObject, forKey: key)
-      let cachedObject: User = try storage.object(forKey: key)
+      let cachedObject = try storage.object(ofType: User.self, forKey: key)
       XCTAssertEqual(cachedObject, testObject)
     }
 
     try then("it is set to memory too") {
-      let memoryObject: User = try storage.memoryStorage.object(forKey: key)
+      let memoryObject = try storage.memoryStorage.object(ofType: User.self, forKey: key)
       XCTAssertNotNil(memoryObject)
     }
 
     try then("it is set to disk too") {
-      let diskObject: User = try storage.diskStorage.object(forKey: key)
+      let diskObject = try storage.diskStorage.object(ofType: User.self, forKey: key)
       XCTAssertNotNil(diskObject)
     }
   }
@@ -43,7 +43,7 @@ final class HybridStorageTests: XCTestCase {
   func testEntry() throws {
     let expiryDate = Date()
     try storage.setObject(testObject, forKey: key, expiry: .date(expiryDate))
-    let entry: Entry<User> = try storage.entry(forKey: key)
+    let entry = try storage.entry(ofType: User.self, forKey: key)
 
     XCTAssertEqual(entry.object, testObject)
     XCTAssertEqual(entry.expiry.date, expiryDate)
@@ -53,12 +53,12 @@ final class HybridStorageTests: XCTestCase {
   func testObjectCopyToMemory() throws {
     try when("set to disk only") {
       try storage.diskStorage.setObject(testObject, forKey: key)
-      let cachedObject: User = try storage.object(forKey: key) as User
+      let cachedObject: User = try storage.object(ofType: User.self, forKey: key)
       XCTAssertEqual(cachedObject, testObject)
     }
 
     try then("there is no object in memory") {
-      let inMemoryCachedObject = try storage.memoryStorage.object(forKey: key) as User
+      let inMemoryCachedObject = try storage.memoryStorage.object(ofType: User.self, forKey: key)
       XCTAssertEqual(inMemoryCachedObject, testObject)
     }
   }
@@ -67,22 +67,22 @@ final class HybridStorageTests: XCTestCase {
   func testRemoveObject() throws {
     try given("set to storage") {
       try storage.setObject(testObject, forKey: key)
-      XCTAssertNotNil(try storage.object(forKey: key) as User)
+      XCTAssertNotNil(try storage.object(ofType: User.self, forKey: key))
     }
 
     try when("remove object from storage") {
       try storage.removeObject(forKey: key)
-      let cachedObject = try? storage.object(forKey: key) as User
+      let cachedObject = try? storage.object(ofType: User.self, forKey: key)
       XCTAssertNil(cachedObject)
     }
 
     then("there is no object in memory") {
-      let memoryObject = try? storage.memoryStorage.object(forKey: key) as User
+      let memoryObject = try? storage.memoryStorage.object(ofType: User.self, forKey: key)
       XCTAssertNil(memoryObject)
     }
 
     then("there is no object on disk") {
-      let diskObject = try? storage.diskStorage.object(forKey: key) as User
+      let diskObject = try? storage.diskStorage.object(ofType: User.self, forKey: key)
       XCTAssertNil(diskObject)
     }
   }
@@ -92,16 +92,16 @@ final class HybridStorageTests: XCTestCase {
     try when("set and remove all") {
       try storage.setObject(testObject, forKey: key)
       try storage.removeAll()
-      XCTAssertNil(try? storage.object(forKey: key) as User)
+      XCTAssertNil(try? storage.object(ofType: User.self, forKey: key))
     }
 
     then("there is no object in memory") {
-      let memoryObject = try? storage.memoryStorage.object(forKey: key) as User
+      let memoryObject = try? storage.memoryStorage.object(ofType: User.self, forKey: key)
       XCTAssertNil(memoryObject)
     }
 
     then("there is no object on disk") {
-      let diskObject = try? storage.diskStorage.object(forKey: key) as User
+      let diskObject = try? storage.diskStorage.object(ofType: User.self, forKey: key)
       XCTAssertNil(diskObject)
     }
   }
@@ -132,8 +132,8 @@ final class HybridStorageTests: XCTestCase {
     }
 
     then("object with key2 survived") {
-      XCTAssertNil(try? storage.object(forKey: key1) as User)
-      XCTAssertNotNil(try? storage.object(forKey: key2) as User)
+      XCTAssertNil(try? storage.object(ofType: User.self, forKey: key1))
+      XCTAssertNotNil(try? storage.object(ofType: User.self, forKey: key2))
     }
   }
 }

--- a/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
@@ -20,7 +20,7 @@ final class MemoryStorageTests: XCTestCase {
   /// Test that it saves an object
   func testSetObject() {
     storage.setObject(testObject, forKey: key)
-    let cachedObject: User = try! storage.object(forKey: key)
+    let cachedObject = try! storage.object(ofType: User.self, forKey: key)
     XCTAssertNotNil(cachedObject)
     XCTAssertEqual(cachedObject.firstName, testObject.firstName)
     XCTAssertEqual(cachedObject.lastName, testObject.lastName)
@@ -28,12 +28,12 @@ final class MemoryStorageTests: XCTestCase {
 
   func testCacheEntry() {
     // Returns nil if entry doesn't exist
-    var entry = try? storage.entry(forKey: key) as Entry<User>
+    var entry = try? storage.entry(ofType: User.self, forKey: key)
     XCTAssertNil(entry)
 
     // Returns entry if object exists
     storage.setObject(testObject, forKey: key)
-    entry = try! storage.entry(forKey: key)
+    entry = try! storage.entry(ofType: User.self, forKey: key)
 
     XCTAssertEqual(entry?.object.firstName, testObject.firstName)
     XCTAssertEqual(entry?.object.lastName, testObject.lastName)
@@ -44,7 +44,7 @@ final class MemoryStorageTests: XCTestCase {
   func testRemoveObject() {
     storage.setObject(testObject, forKey: key)
     storage.removeObject(forKey: key)
-    let cachedObject = try? storage.object(forKey: key) as User
+    let cachedObject = try? storage.object(ofType: User.self, forKey: key)
     XCTAssertNil(cachedObject)
   }
 
@@ -53,7 +53,7 @@ final class MemoryStorageTests: XCTestCase {
     let expiry: Expiry = .date(Date().addingTimeInterval(-10))
     storage.setObject(testObject, forKey: key, expiry: expiry)
     storage.removeObjectIfExpired(forKey: key)
-    let cachedObject = try? storage.object(forKey: key) as User
+    let cachedObject = try? storage.object(ofType: User.self, forKey: key)
 
     XCTAssertNil(cachedObject)
   }
@@ -62,7 +62,7 @@ final class MemoryStorageTests: XCTestCase {
   func testRemoveObjectIfExpiredWhenNotExpired() {
     storage.setObject(testObject, forKey: key)
     storage.removeObjectIfExpired(forKey: key)
-    let cachedObject: User = try! storage.object(forKey: key)
+    let cachedObject = try! storage.object(ofType: User.self, forKey: key)
 
     XCTAssertNotNil(cachedObject)
   }
@@ -71,7 +71,7 @@ final class MemoryStorageTests: XCTestCase {
   func testRemoveAll() {
     storage.setObject(testObject, forKey: key)
     storage.removeAll()
-    let cachedObject = try? storage.object(forKey: key) as User
+    let cachedObject = try? storage.object(ofType: User.self, forKey: key)
     XCTAssertNil(cachedObject)
   }
 
@@ -84,8 +84,8 @@ final class MemoryStorageTests: XCTestCase {
     storage.setObject(testObject, forKey: key1, expiry: expiry1)
     storage.setObject(testObject, forKey: key2, expiry: expiry2)
     storage.removeExpiredObjects()
-    let object1 = try? storage.object(forKey: key1) as User
-    let object2 = try! storage.object(forKey: key2) as User
+    let object1 = try? storage.object(ofType: User.self, forKey: key1)
+    let object2 = try! storage.object(ofType: User.self, forKey: key2)
 
     XCTAssertNil(object1)
     XCTAssertNotNil(object2)

--- a/Tests/iOS/Tests/Storage/StorageTests.swift
+++ b/Tests/iOS/Tests/Storage/StorageTests.swift
@@ -18,7 +18,7 @@ final class StorageTests: XCTestCase {
 
   func testSync() throws {
     try storage.setObject(user, forKey: "user")
-    let cachedObject = try storage.object(forKey: "user") as User
+    let cachedObject = try storage.object(ofType: User.self, forKey: "user")
 
     XCTAssertEqual(cachedObject, user)
   }
@@ -27,7 +27,7 @@ final class StorageTests: XCTestCase {
     let expectation = self.expectation(description: #function)
     storage.async.setObject(user, forKey: "user", expiry: nil, completion: { _ in })
 
-    storage.async.object(forKey: "user", completion: { (result: Result<User>) in
+    storage.async.object(ofType: User.self, forKey: "user", completion: { result in
       switch result {
       case .value(let cachedUser):
         XCTAssertEqual(cachedUser, self.user)

--- a/Tests/iOS/Tests/Storage/SyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/SyncStorageTests.swift
@@ -19,7 +19,7 @@ final class SyncStorageTests: XCTestCase {
 
   func testSetObject() throws {
     try storage.setObject(user, forKey: "user")
-    let cachedObject = try storage.object(forKey: "user") as User
+    let cachedObject = try storage.object(ofType: User.self, forKey: "user")
 
     XCTAssertEqual(cachedObject, user)
   }

--- a/Tests/iOS/Tests/Storage/TypeWrapperStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/TypeWrapperStorageTests.swift
@@ -19,44 +19,44 @@ final class TypeWrapperStorageTests: XCTestCase {
 
   func testSetPrimitive() throws {
     try storage.setObject(true, forKey: "bool")
-    XCTAssertEqual(try storage.object(forKey: "bool"), true)
+    XCTAssertEqual(try storage.object(ofType: Bool.self, forKey: "bool"), true)
 
     try storage.setObject([true, false, true], forKey: "array of bools")
-    XCTAssertEqual(try storage.object(forKey: "array of bools"), [true, false, true])
+    XCTAssertEqual(try storage.object(ofType: [Bool].self, forKey: "array of bools"), [true, false, true])
 
     try storage.setObject("one", forKey: "string")
-    XCTAssertEqual(try storage.object(forKey: "string"), "one")
+    XCTAssertEqual(try storage.object(ofType: String.self, forKey: "string"), "one")
 
     try storage.setObject(["one", "two", "three"], forKey: "array of strings")
-    XCTAssertEqual(try storage.object(forKey: "array of strings"), ["one", "two", "three"])
+    XCTAssertEqual(try storage.object(ofType: [String].self, forKey: "array of strings"), ["one", "two", "three"])
 
     try storage.setObject(10, forKey: "int")
-    XCTAssertEqual(try storage.object(forKey: "int"), 10)
+    XCTAssertEqual(try storage.object(ofType: Int.self, forKey: "int"), 10)
 
     try storage.setObject([1, 2, 3], forKey: "array of ints")
-    XCTAssertEqual(try storage.object(forKey: "array of ints"), [1, 2, 3])
+    XCTAssertEqual(try storage.object(ofType: [Int].self, forKey: "array of ints"), [1, 2, 3])
 
     let float: Float = 1.1
     try storage.setObject(float, forKey: "float")
-    XCTAssertEqual(try storage.object(forKey: "float"), float)
+    XCTAssertEqual(try storage.object(ofType: Float.self, forKey: "float"), float)
 
     let floats: [Float] = [1.1, 1.2, 1.3]
     try storage.setObject(floats, forKey: "array of floats")
-    XCTAssertEqual(try storage.object(forKey: "array of floats"), floats)
+    XCTAssertEqual(try storage.object(ofType: [Float].self, forKey: "array of floats"), floats)
 
     let double: Double = 1.1
     try storage.setObject(double, forKey: "double")
-    XCTAssertEqual(try storage.object(forKey: "double"), double)
+    XCTAssertEqual(try storage.object(ofType: Double.self, forKey: "double"), double)
 
     let doubles: [Double] = [1.1, 1.2, 1.3]
     try storage.setObject(doubles, forKey: "array of doubles")
-    XCTAssertEqual(try storage.object(forKey: "array of doubles"), doubles)
+    XCTAssertEqual(try storage.object(ofType: [Double].self, forKey: "array of doubles"), doubles)
   }
 
   func testWithSet() throws {
     let set = Set<Int>(arrayLiteral: 1, 2, 3)
     try storage.setObject(set, forKey: "set")
-    XCTAssertEqual(try storage.object(forKey: "set") as Set<Int>, set)
+    XCTAssertEqual(try storage.object(ofType: Set<Int>.self, forKey: "set") as Set<Int>, set)
   }
 
   func testWithSimpleDictionary() throws {
@@ -67,7 +67,7 @@ final class TypeWrapperStorageTests: XCTestCase {
 
 
     try storage.setObject(dict, forKey: "dict")
-    let cachedObject = try storage.object(forKey: "dict") as [String: Int]
+    let cachedObject = try storage.object(ofType: [String: Int].self, forKey: "dict") as [String: Int]
     XCTAssertEqual(cachedObject, dict)
   }
 
@@ -87,8 +87,8 @@ final class TypeWrapperStorageTests: XCTestCase {
     try storage.setObject(user, forKey: key)
     try storage.setObject("Dragonstone", forKey: key)
 
-    XCTAssertNil(try? storage.object(forKey: key) as User)
-    XCTAssertNotNil(try storage.object(forKey: key) as String)
+    XCTAssertNil(try? storage.object(ofType: User.self, forKey: key))
+    XCTAssertNotNil(try storage.object(ofType: String.self, forKey: key))
   }
 
   func testIntFloat() throws {
@@ -96,8 +96,8 @@ final class TypeWrapperStorageTests: XCTestCase {
     try storage.setObject(10, forKey: key)
 
     try then("Casting to int or float is the same") {
-      XCTAssertEqual(try storage.object(forKey: key) as Int, 10)
-      XCTAssertEqual(try storage.object(forKey: key) as Float, 10)
+      XCTAssertEqual(try storage.object(ofType: Int.self, forKey: key), 10)
+      XCTAssertEqual(try storage.object(ofType: Float.self, forKey: key), 10)
     }
   }
 
@@ -106,8 +106,8 @@ final class TypeWrapperStorageTests: XCTestCase {
     try storage.setObject(10.5, forKey: key)
 
     try then("Casting to float or double is the same") {
-      XCTAssertEqual(try storage.object(forKey: key) as Float, 10.5)
-      XCTAssertEqual(try storage.object(forKey: key) as Double, 10.5)
+      XCTAssertEqual(try storage.object(ofType: Float.self, forKey: key), 10.5)
+      XCTAssertEqual(try storage.object(ofType: Double.self, forKey: key), 10.5)
     }
   }
 
@@ -115,7 +115,7 @@ final class TypeWrapperStorageTests: XCTestCase {
     try storage.setObject("Hello", forKey: "string")
 
     do {
-      let cachedObject = try storage.object(forKey: "string") as Int
+      let cachedObject = try storage.object(ofType: Int.self, forKey: "string")
       XCTAssertEqual(cachedObject, 10)
     } catch {
       XCTAssertTrue(error is DecodingError)


### PR DESCRIPTION
- Before we would need to do type inference, either by declaring `type` or using `as`. This will be even harder for async functions in which casting to `Result` is required.
- Now we add `typeOf` parameter, so that it is clear.