### PR TITLE
Add ObjectConverter

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -42,6 +42,12 @@
 		D21B669E1F6A724700125DE1 /* MemoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF984E1F694FFA00CE8F68 /* MemoryConfig.swift */; };
 		D21B66A11F6A747000125DE1 /* ImageWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98761F69513800CE8F68 /* ImageWrapperTests.swift */; };
 		D236F31A1F6BEF73004EE01F /* StorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D236F3191F6BEF73004EE01F /* StorageTests.swift */; };
+		D285143B1F6FFB6300C674D1 /* ObjectSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285143A1F6FFB6300C674D1 /* ObjectSerializer.swift */; };
+		D285143C1F6FFB6300C674D1 /* ObjectSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285143A1F6FFB6300C674D1 /* ObjectSerializer.swift */; };
+		D285143D1F6FFB6300C674D1 /* ObjectSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285143A1F6FFB6300C674D1 /* ObjectSerializer.swift */; };
+		D28A1D221F6FFEF50030DF81 /* ObjectConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285143E1F6FFE1F00C674D1 /* ObjectConverterTests.swift */; };
+		D28A1D231F6FFEF50030DF81 /* ObjectConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285143E1F6FFE1F00C674D1 /* ObjectConverterTests.swift */; };
+		D28A1D241F6FFEF60030DF81 /* ObjectConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285143E1F6FFE1F00C674D1 /* ObjectConverterTests.swift */; };
 		D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291CDF1C28374800B702C9 /* TestHelper+iOS.swift */; };
 		D28C9BAF1F67EF8300C180C1 /* UIImage+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5291DA01C28405900B702C9 /* UIImage+ExtensionsTests.swift */; };
 		D292DAF11F6A85F30060F614 /* SyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292DAF01F6A85F30060F614 /* SyncStorage.swift */; };
@@ -131,6 +137,8 @@
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D236F3191F6BEF73004EE01F /* StorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageTests.swift; sourceTree = "<group>"; };
+		D285143A1F6FFB6300C674D1 /* ObjectSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectSerializer.swift; sourceTree = "<group>"; };
+		D285143E1F6FFE1F00C674D1 /* ObjectConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectConverterTests.swift; sourceTree = "<group>"; };
 		D292DAF01F6A85F30060F614 /* SyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStorage.swift; sourceTree = "<group>"; };
 		D292DAF41F6A94000060F614 /* AsyncStorageAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStorageAware.swift; sourceTree = "<group>"; };
 		D292DAF81F6A962D0060F614 /* AsyncStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStorage.swift; sourceTree = "<group>"; };
@@ -279,6 +287,7 @@
 				D2CF98591F694FFA00CE8F68 /* StorageError.swift */,
 				D2CF98861F695B8F00CE8F68 /* Types.swift */,
 				D292DAFC1F6A970B0060F614 /* Result.swift */,
+				D285143A1F6FFB6300C674D1 /* ObjectSerializer.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -324,6 +333,7 @@
 				D2CF98751F69513800CE8F68 /* ExpiryTests.swift */,
 				D2CF98761F69513800CE8F68 /* ImageWrapperTests.swift */,
 				D2CF98771F69513800CE8F68 /* TypeWrapperTests.swift */,
+				D285143E1F6FFE1F00C674D1 /* ObjectConverterTests.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -783,6 +793,7 @@
 			files = (
 				D21B66861F6A723C00125DE1 /* Entry.swift in Sources */,
 				D21B66971F6A724000125DE1 /* StorageAware.swift in Sources */,
+				D285143D1F6FFB6300C674D1 /* ObjectSerializer.swift in Sources */,
 				D21B669D1F6A724600125DE1 /* DiskConfig.swift in Sources */,
 				D21B66961F6A724000125DE1 /* Storage.swift in Sources */,
 				D21B66871F6A723C00125DE1 /* ExpirationMode.swift in Sources */,
@@ -812,6 +823,7 @@
 				D2CF98201F69427C00CE8F68 /* TestCase+Extensions.swift in Sources */,
 				D2CF98231F69427C00CE8F68 /* TestHelper.swift in Sources */,
 				D2CF98261F69427C00CE8F68 /* User.swift in Sources */,
+				D28A1D241F6FFEF60030DF81 /* ObjectConverterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -820,6 +832,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2CF987E1F69513800CE8F68 /* ExpiryTests.swift in Sources */,
+				D28A1D231F6FFEF50030DF81 /* ObjectConverterTests.swift in Sources */,
 				D2CF98891F695F9400CE8F68 /* TypeWrapperStorageTests.swift in Sources */,
 				D2CF98821F69513800CE8F68 /* HybridStorageTests.swift in Sources */,
 				D2CF98831F69513800CE8F68 /* MemoryStorageTests.swift in Sources */,
@@ -845,6 +858,7 @@
 			files = (
 				D21B667D1F6A723C00125DE1 /* Entry.swift in Sources */,
 				D21B66911F6A723F00125DE1 /* StorageAware.swift in Sources */,
+				D285143C1F6FFB6300C674D1 /* ObjectSerializer.swift in Sources */,
 				D21B669B1F6A724600125DE1 /* DiskConfig.swift in Sources */,
 				D21B66901F6A723F00125DE1 /* Storage.swift in Sources */,
 				D21B667E1F6A723C00125DE1 /* ExpirationMode.swift in Sources */,
@@ -872,6 +886,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D292DB051F6AA0730060F614 /* AsyncStorageTests.swift in Sources */,
+				D28A1D221F6FFEF50030DF81 /* ObjectConverterTests.swift in Sources */,
 				D2CF98221F69427C00CE8F68 /* TestHelper.swift in Sources */,
 				D21B66A11F6A747000125DE1 /* ImageWrapperTests.swift in Sources */,
 				D2CF98251F69427C00CE8F68 /* User.swift in Sources */,
@@ -888,6 +903,7 @@
 			files = (
 				D2CF98651F694FFA00CE8F68 /* Entry.swift in Sources */,
 				D2CF98681F694FFA00CE8F68 /* ImageWrapper.swift in Sources */,
+				D285143B1F6FFB6300C674D1 /* ObjectSerializer.swift in Sources */,
 				D2CF986C1F694FFA00CE8F68 /* HybridStorage.swift in Sources */,
 				D2CF98871F695B8F00CE8F68 /* Types.swift in Sources */,
 				D2CF98621F694FFA00CE8F68 /* Date+Extensions.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ While `Storage` can persist `String` or `Data`, we recommend persisting the stro
 You can use `ObjectConverter` to convert json dictionary, string or data to objects.
 
 ```swift
-let user = ObjectConverter.convert(jsonData, to: User.self)
+let user = ObjectConverter.convert(jsonString, to: User.self)
 let cities = Object.Converter.convert(jsonDictionary, to: [City].self)
 let dragons = ObjectConverter.convert(jsonData, to: [Dragon].self)
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   * [Async APIS](#async-apis)
   * [Expiry date](#expiry-date)
 * [What about images?](#what-about-images)
+* [Handling JSON response](#handling-json-response)
 * [Installation](#installation)
 * [Author](#author)
 * [Contributing](#contributing)
@@ -271,6 +272,33 @@ let icon = try? storage.object(ofType: ImageWrapper.self, forKey: "star").image
 ```
 
 If you want to load image into `UIImageView` or `NSImageView`, then we also have a nice gift for you. It's called [Imaginary](https://github.com/hyperoslo/Imaginary) and uses `Cache` under the hood to make you life easier when it comes to working with remote images.
+
+## Handling JSON response
+
+Most of the time, our use case is to fetch some json from backend, display it while saving the json to storage for future uses. If you're using libraries like [Alamofire](https://github.com/Alamofire/Alamofire) or [Malibu](https://github.com/hyperoslo/Malibu), you mostly get json in the form of dictionary, string, or data.
+
+While `Storage` can persist `String` or `Data`, we recommend persisting the strong typed objects, since those are the objects that you will use to display in UI. Furthermore, if the json data can't be converted to strongly typed objects, what's the point of saving it ? 😉
+
+You can use `ObjectConverter` to convert json dictionary, string or data to objects.
+
+```swift
+let user = ObjectConverter.convert(jsonData, to: User.self)
+let cities = Object.Converter.convert(jsonDictionary, to: [City].self)
+let dragons = ObjectConverter.convert(jsonData, to: [Dragon].self)
+```
+
+This is how you perform object converting and saving with `Alamofire`
+
+```swift
+Alamofire.request("https://gameofthrones.org/mostFavoriteCharacter").responseString { response in
+  do {
+    let user = try ObjectConverter.convert(response.result.value, to: User.self)
+    try storage.setObject(user, forKey: "most favorite character")
+  } catch {
+    print(error)
+  }
+}
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 * [Key features](#key-features)
 * [Usage](#usage)
   * [Storage](#storage)
-  * [Error handling](#error-handling)
   * [Configuration](#configuration)
   * [Sync APIs](#sync-apis)
   * [Async APIS](#async-apis)
@@ -49,7 +48,7 @@ with out-of-box implementations and great customization possibilities. `Cache` u
 
 ### Storage
 
-`Cache` is built based on [Chain-of-responsibility pattern](https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern), in which there are many processing objects, each knows how to do 1 task and delegate to the next one. But that's just implementation detail. All you need to know is `Storage`, it saves and loads `Codable` objects.
+`Cache` is built based on [Chain-of-responsibility pattern](https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern), in which there are many processing objects, each knows how to do 1 task and delegates to the next one. But that's just implementation detail. All you need to know is `Storage`, it saves and loads `Codable` objects.
 
 `Storage` has disk storage and an optional memory storage. Memory storage should be less time and memory consuming, while disk storage is used for content that outlives the application life-cycle, see it more like a convenient way to store user information that should persist across application launches.
 
@@ -63,7 +62,21 @@ let memoryConfig = MemoryConfig(expiry: .never, countLimit: 10, totalCostLimit: 
 let storage = try? Storage(diskConfig: diskConfig, memoryConfig: memoryConfig)
 ```
 
-### Error handling
+#### Codable types
+
+`Storage` supports any objects that conform to [Codable](https://developer.apple.com/documentation/swift/codable) protocol. You can [make your own things conform to Codable](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types) so that can be saved and loaded from `Storage`.
+
+The supported types are
+
+- Primitives like `Int`, `Float`, `String`, `Bool`, ...
+- Array of primitives like `[Int]`, `[Float]`, `[Double]`, ...
+- Set of primitives like `Set<String>`, `Set<Int>`, ...
+- Simply dictionary like `[String: Int]`, `[String: String]`, ...
+- `Date`
+- `URL`
+- `Data`
+
+#### Error handling
 
 Error handling is done via `try catch`. `Storage` throws errors in terms of `StorageError`.
 
@@ -131,15 +144,15 @@ On iOS, tvOS we can also specify `protectionType` on `DiskConfig` to add a level
 
 ### Sync APIs
 
-`Storage` is sync by default. It supports any objects that conform to [Codable](https://developer.apple.com/documentation/swift/codable) protocol. It can be `Int`, `Bool`, `Array<Int>`, `Set<String>`, ... You can [make your own things conform to Codable](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types) so that can be saved and loaded from `Storage`.
-
-Storage is `thead safe`, you can access it from any queues. All Sync functions are constrained by `StorageAware` protocol.
+`Storage` is sync by default and is `thead safe`, you can access it from any queues. All Sync functions are constrained by `StorageAware` protocol.
 
 ```swift
 // Save to storage
 try? storage.setObject(10, forKey: "score")
 try? storage.setObject("Oslo", forKey: "my favorite city", expiry: .never)
 try? storage.setObject(["alert", "sounds", "badge"], forKey: "notifications")
+try? storage.setObject(data, forKey: "a bunch of bytes")
+try? storage.setObject(authorizeURL, forKey: "authorization URL")
 
 // Load from storage
 let score = try? storage.object(ofType: Int.self, forKey: "score")

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ print(entry?.meta)
 
 #### Custom Codable
 
-`Codable` works for simple dictionary like `[String: Int]`, `[String: String]`, ... It does not work for [String: Any]` as `Any` is not `Codable` conformance, it will raise `fatal` error at runtime. So when you get json from backend responses, you need to convert that to your custom `Codable` objects and save to `Storage` instead.
+`Codable` works for simple dictionary like `[String: Int]`, `[String: String]`, ... It does not work for `[String: Any]` as `Any` is not `Codable` conformance, it will raise `fatal error` at runtime. So when you get json from backend responses, you need to convert that to your custom `Codable` objects and save to `Storage` instead.
 
 ```swift
 struct User: Codable {

--- a/Source/Shared/Library/ObjectSerializer.swift
+++ b/Source/Shared/Library/ObjectSerializer.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Convert json string, dictionary, data to Codable objects
+public class ObjectConverter {
+  /// Convert json string to Codable object
+  ///
+  /// - Parameters:
+  ///   - string: Json string.
+  ///   - type: Type information.
+  /// - Returns: Codable object.
+  /// - Throws: Error if failed.
+  static func convert<T: Codable>(_ string: String, to type: T.Type) throws -> T {
+    guard let data = string.data(using: .utf8) else {
+      throw StorageError.decodingFailed
+    }
+
+    return try convert(data, to: type.self)
+  }
+
+  /// Convert json dictionary to Codable object
+  ///
+  /// - Parameters:
+  ///   - json: Json dictionary.
+  ///   - type: Type information.
+  /// - Returns: Codable object
+  /// - Throws: Error if failed
+  static func convert<T: Codable>(_ json: [String: Any], to type: T.Type) throws -> T {
+    let data = try JSONSerialization.data(withJSONObject: json, options: [])
+    return try convert(data, to: type)
+  }
+
+  /// Convert json data to Codable object
+  ///
+  /// - Parameters:
+  ///   - json: Json dictionary.
+  ///   - type: Type information.
+  /// - Returns: Codable object
+  /// - Throws: Error if failed
+  static func convert<T: Codable>(_ data: Data, to type: T.Type) throws -> T {
+    return try JSONDecoder().decode(T.self, from: data)
+  }
+}

--- a/Tests/iOS/Tests/Library/ObjectConverterTests.swift
+++ b/Tests/iOS/Tests/Library/ObjectConverterTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Cache
+
+final class ObjectStorageTests: XCTestCase {
+  private var storage: HybridStorage!
+
+  override func setUp() {
+    super.setUp()
+    let memory = MemoryStorage(config: MemoryConfig())
+    let disk = try! DiskStorage(config: DiskConfig(name: "HybridDisk"))
+
+    storage = HybridStorage(memoryStorage: memory, diskStorage: disk)
+  }
+
+  override func tearDown() {
+    try? storage.removeAll()
+    super.tearDown()
+  }
+
+  func testJsonDictionary() throws {
+    let json: [String: Any] = [
+      "first_name": "John",
+      "last_name": "Snow"
+    ]
+
+    let user = try ObjectConverter.convert(json, to: User.self)
+    try storage.setObject(user, forKey: "user")
+
+    let cachedObject = try storage.object(ofType: User.self, forKey: "user")
+    XCTAssertEqual(user, cachedObject)
+  }
+
+  func testJsonString() throws {
+    let string: String = "{\"first_name\": \"John\", \"last_name\": \"Snow\"}"
+
+    let user = try ObjectConverter.convert(string, to: User.self)
+    try storage.setObject(user, forKey: "user")
+
+    let cachedObject = try storage.object(ofType: User.self, forKey: "user")
+    XCTAssertEqual(cachedObject.firstName, "John")
+  }
+}
+

--- a/Tests/iOS/Tests/Storage/TypeWrapperStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/TypeWrapperStorageTests.swift
@@ -68,6 +68,22 @@ final class TypeWrapperStorageTests: XCTestCase {
     }
   }
 
+  func testSetDate() throws {
+    let date = Date(timeIntervalSince1970: 100)
+    try storage.setObject(date, forKey: "date")
+    let cachedObject = try storage.object(ofType: Date.self, forKey: "date")
+
+    XCTAssertEqual(date, cachedObject)
+  }
+
+  func testSetURL() throws {
+    let url = URL(string: "https://hyper.no")
+    try storage.setObject(url, forKey: "url")
+    let cachedObject = try storage.object(ofType: URL.self, forKey: "url")
+
+    XCTAssertEqual(url, cachedObject)
+  }
+
   func testWithSet() throws {
     let set = Set<Int>(arrayLiteral: 1, 2, 3)
     try storage.setObject(set, forKey: "set")

--- a/Tests/iOS/Tests/Storage/TypeWrapperStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/TypeWrapperStorageTests.swift
@@ -53,6 +53,21 @@ final class TypeWrapperStorageTests: XCTestCase {
     XCTAssertEqual(try storage.object(ofType: [Double].self, forKey: "array of doubles"), doubles)
   }
 
+  func testSetData() {
+    do {
+      let string = "Hello"
+      let data = string.data(using: .utf8)
+      try storage.setObject(data, forKey: "data")
+
+      let cachedObject = try storage.object(ofType: Data.self, forKey: "data")
+      let cachedString = String(data: cachedObject, encoding: .utf8)
+
+      XCTAssertEqual(cachedString, string)
+    } catch {
+      XCTFail(error.localizedDescription)
+    }
+  }
+
   func testWithSet() throws {
     let set = Set<Int>(arrayLiteral: 1, 2, 3)
     try storage.setObject(set, forKey: "set")


### PR DESCRIPTION
- Add ObjectSerializer to convert json dictionary, data, string to strongly type objects.
- Update README to reflect this.
- Also, update README to list all the things that conform to `Codable`, hence can be persisted with `Storage`