### PR TITLE
Use fileprivate

### DIFF
--- a/Source/Shared/Storage/AsyncStorage.swift
+++ b/Source/Shared/Storage/AsyncStorage.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Manipulate storage in a "all async" manner.
 /// The completion closure will be called when operation completes.
 public class AsyncStorage {
-  private let internalStorage: StorageAware
+  fileprivate let internalStorage: StorageAware
   public let serialQueue: DispatchQueue
 
   init(storage: StorageAware, serialQueue: DispatchQueue) {

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -10,7 +10,7 @@ final class DiskStorage {
   /// File manager to read/write to the disk
   fileprivate let fileManager: FileManager
   /// Configuration
-  private let config: DiskConfig
+  fileprivate let config: DiskConfig
   /// The computed path `directory+name`
   let path: String
 

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -7,7 +7,7 @@ final class MemoryStorage {
   // Memory cache keys
   fileprivate var keys = Set<String>()
   /// Configuration
-  private let config: MemoryConfig
+  fileprivate let config: MemoryConfig
 
   // MARK: - Initialization
 

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -38,7 +38,7 @@ public class Storage {
   }
 
   /// Used for async operations
-  public lazy var async: AsyncStorageAware = AsyncStorage(storage: self.interalStorage, serialQueue: self.serialQueue)
+  public lazy var async: AsyncStorage = AsyncStorage(storage: self.interalStorage, serialQueue: self.serialQueue)
 }
 
 extension Storage: StorageAware {

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Synchronous by default. Use `async` for asynchronous operations.
 public class Storage {
   /// Used for sync operations
-  private let sync: StorageAware
+  fileprivate let sync: StorageAware
 
   /// Queue used by both sync and async storages
   private let serialQueue = DispatchQueue(label: "Cache.Storage.SerialQueue")
@@ -43,23 +43,23 @@ public class Storage {
 
 extension Storage: StorageAware {
   public func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
-    return try sync.entry(ofType: type, forKey: key)
+    return try self.sync.entry(ofType: type, forKey: key)
   }
 
   public func removeObject(forKey key: String) throws {
-    try sync.removeObject(forKey: key)
+    try self.sync.removeObject(forKey: key)
   }
 
   public func setObject<T: Codable>(_ object: T, forKey key: String,
                                     expiry: Expiry? = nil) throws {
-    try sync.setObject(object, forKey: key, expiry: expiry)
+    try self.sync.setObject(object, forKey: key, expiry: expiry)
   }
 
   public func removeAll() throws {
-    try sync.removeAll()
+    try self.sync.removeAll()
   }
 
   public func removeExpiredObjects() throws {
-    try sync.removeExpiredObjects()
+    try self.sync.removeExpiredObjects()
   }
 }

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Manipulate storage in a "all sync" manner.
 /// Block the current queue until the operation completes.
 public class SyncStorage {
-  private let internalStorage: StorageAware
+  fileprivate let internalStorage: StorageAware
   fileprivate let serialQueue: DispatchQueue
 
   init(storage: StorageAware, serialQueue: DispatchQueue) {


### PR DESCRIPTION
- The project builds fine, but when using it as a pod in another project, it complains about using `private` in extensions. This fixes that.
- Also, expose `async` as concrete type `AsyncStorage` instead of protocol. Because protocol does not have default paramater