### PR TITLE
Fix "expiry" values

### DIFF
--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -18,7 +18,7 @@ extension HybridStorage: StorageAware {
     } catch {
       let entry = try diskStorage.entry(ofType: type, forKey: key)
       // set back to memoryStorage
-      memoryStorage.setObject(entry.object, forKey: key)
+      memoryStorage.setObject(entry.object, forKey: key, expiry: entry.expiry)
       return entry
     }
   }

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -37,7 +37,7 @@ extension MemoryStorage: StorageAware {
   }
 
   func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) {
-    let capsule = MemoryCapsule(value: object, expiry: expiry ?? config.expiry)
+    let capsule = MemoryCapsule(value: object, expiry: .date(expiry?.date ?? config.expiry.date))
     cache.setObject(capsule, forKey: NSString(string: key))
     keys.insert(key)
   }

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -45,6 +45,12 @@ public protocol StorageAware {
    Clears all expired objects.
    */
   func removeExpiredObjects() throws
+  
+  /**
+   Check if an expired object by the given key.
+   - Parameter key: Unique key to identify the object.
+  */
+  func isExpiredObject<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Bool
 }
 
 public extension StorageAware {
@@ -58,6 +64,15 @@ public extension StorageAware {
       return true
     } catch {
       return false
+    }
+  }
+  
+  func isExpiredObject<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Bool {
+    do {
+      let entry = try self.entry(ofType: type, forKey: key)
+      return entry.expiry.isExpired
+    } catch {
+      return true
     }
   }
 }

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -129,6 +129,14 @@ final class DiskStorageTests: XCTestCase {
     let cachedObject: User? = try storage.object(ofType: User.self, forKey: key)
     XCTAssertNotNil(cachedObject)
   }
+  
+  /// Test expired object
+  func testExpiredObject() throws {
+    try storage.setObject(testObject, forKey: key, expiry: .seconds(0.9))
+    XCTAssertFalse(try! storage.isExpiredObject(ofType: User.self, forKey: key))
+    sleep(1)
+    XCTAssertTrue(try! storage.isExpiredObject(ofType: User.self, forKey: key))
+  }
 
   /// Test that it clears cache directory
   func testClear() throws {

--- a/Tests/iOS/Tests/Storage/HybridStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/HybridStorageTests.swift
@@ -61,6 +61,26 @@ final class HybridStorageTests: XCTestCase {
       XCTAssertEqual(inMemoryCachedObject, testObject)
     }
   }
+  
+  func testEntityExpiryForObjectCopyToMemory() throws {
+    let date = Date().addingTimeInterval(3)
+    try when("set to disk only") {
+      try storage.diskStorage.setObject(testObject, forKey: key, expiry: .seconds(3))
+      let entry = try storage.entry(ofType: User.self, forKey: key)
+      //accuracy for slow disk processes
+      XCTAssertEqual(entry.expiry.date.timeIntervalSinceReferenceDate,
+                     date.timeIntervalSinceReferenceDate,
+                     accuracy: 1.0)
+    }
+    
+    try then("there is no object in memory") {
+      let entry = try storage.memoryStorage.entry(ofType: User.self, forKey: key)
+      //accuracy for slow disk processes
+      XCTAssertEqual(entry.expiry.date.timeIntervalSinceReferenceDate,
+                     date.timeIntervalSinceReferenceDate,
+                     accuracy: 1.0)
+    }
+  }
 
   /// Removes cached object from memory and disk
   func testRemoveObject() throws {

--- a/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
@@ -39,6 +39,21 @@ final class MemoryStorageTests: XCTestCase {
     XCTAssertEqual(entry?.object.lastName, testObject.lastName)
     XCTAssertEqual(entry?.expiry.date, config.expiry.date)
   }
+  
+  func testSetObjectWithExpiry() {
+    let date = Date().addingTimeInterval(1)
+    storage.setObject(testObject, forKey: key, expiry: .seconds(1))
+    var entry = try! storage.entry(ofType: User.self, forKey: key)
+    XCTAssertEqual(entry.expiry.date.timeIntervalSinceReferenceDate,
+                   date.timeIntervalSinceReferenceDate,
+                   accuracy: 0.1)
+    //Timer vs sleep: do not complicate
+    sleep(1)
+    entry = try! storage.entry(ofType: User.self, forKey: key)
+    XCTAssertEqual(entry.expiry.date.timeIntervalSinceReferenceDate,
+                   date.timeIntervalSinceReferenceDate,
+                   accuracy: 0.1)
+  }
 
   /// Test that it removes cached object
   func testRemoveObject() {

--- a/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
@@ -81,6 +81,14 @@ final class MemoryStorageTests: XCTestCase {
 
     XCTAssertNotNil(cachedObject)
   }
+  
+  /// Test expired object
+  func testExpiredObject() throws {
+    storage.setObject(testObject, forKey: key, expiry: .seconds(0.9))
+    XCTAssertFalse(try! storage.isExpiredObject(ofType: User.self, forKey: key))
+    sleep(1)
+    XCTAssertTrue(try! storage.isExpiredObject(ofType: User.self, forKey: key))
+  }
 
   /// Test that it clears cache directory
   func testRemoveAll() {


### PR DESCRIPTION
While using .seconds case an object never be with expired date and expiry values will be different for memory and disk storages when coped to memory for hybrid storage.

Extended the storage aware protocol with function to check if an object with expired date by key.