### PR TITLE
Removed totalCostLimit from MemoryConfig

### DIFF
--- a/Playgrounds/Storage.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Playgrounds/Storage.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
 </Workspace>

--- a/Source/Shared/Configuration/MemoryConfig.swift
+++ b/Source/Shared/Configuration/MemoryConfig.swift
@@ -6,12 +6,17 @@ public struct MemoryConfig {
   public let expiry: Expiry
   /// The maximum number of objects in memory the cache should hold. 0 means no limit.
   public let countLimit: UInt
-  /// The maximum total cost that the cache can hold before it starts evicting objects. 0 means no limit.
-  public let totalCostLimit: UInt
 
-  public init(expiry: Expiry = .never, countLimit: UInt = 0, totalCostLimit: UInt = 0) {
+  public init(expiry: Expiry = .never, countLimit: UInt = 0) {
     self.expiry = expiry
     self.countLimit = countLimit
-    self.totalCostLimit = totalCostLimit
+  }
+
+  // MARK: - Deprecated
+  @available(*, deprecated,
+  message: "Use init(expiry:countLimit:) instead.",
+  renamed: "init(expiry:countLimit:)")
+  public init(expiry: Expiry = .never, countLimit: UInt = 0, totalCostLimit: UInt = 0) {
+    self.init(expiry: expiry, countLimit: countLimit)
   }
 }

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -14,7 +14,6 @@ final class MemoryStorage {
   init(config: MemoryConfig) {
     self.config = config
     self.cache.countLimit = Int(config.countLimit)
-    self.cache.totalCostLimit = Int(config.totalCostLimit)
   }
 }
 


### PR DESCRIPTION
For NSCache, I think the totalCostLimit doesn't work if you don't use setObject(_ obj: ObjectType, forKey key: KeyType, cost g: Int) and pass a cost of the object which you want to cache.

Also, I think it's not easy to get the cost of each object since they may be any type. So keeping this property may confuse user when they really try to set it.

I checked several image cache libraries based on NSCache and found they did passed the cost of the cached images because it's easy to get an image cost.

```
setObject function in MemoryStorage.swift

func setObject<T: Codable>(_ object: T, forKey key: String, expiry: Expiry? = nil) {
    let capsule = MemoryCapsule(value: object, expiry: .date(expiry?.date ?? config.expiry.date))
    cache.setObject(capsule, forKey: NSString(string: key))
    keys.insert(key)
}
```