### PR TITLE
Fix Bug - Passing the meta to Entry

### DIFF
--- a/Source/Shared/Storage/TypeWrapperStorage.swift
+++ b/Source/Shared/Storage/TypeWrapperStorage.swift
@@ -14,7 +14,7 @@ final class TypeWrapperStorage {
 extension TypeWrapperStorage: StorageAware {
   public func entry<T: Codable>(ofType type: T.Type, forKey key: String) throws -> Entry<T> {
     let wrapperEntry = try internalStorage.entry(ofType: TypeWrapper<T>.self, forKey: key)
-    return Entry(object: wrapperEntry.object.object, expiry: wrapperEntry.expiry)
+    return Entry(object: wrapperEntry.object.object, expiry: wrapperEntry.expiry, meta: wrapperEntry.meta)
   }
 
   public func removeObject(forKey key: String) throws {


### PR DESCRIPTION
The TypeWrapperStorage was not setting the meta property to the generated Entry. This was causing that the Entry meta property was always empty and it was not possible to read the "filePath" information.