### PR TITLE
Feature: file extensions

### DIFF
--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -162,7 +162,15 @@ extension DiskStorage {
    - Returns: A md5 string
    */
   func makeFileName(for key: String) -> String {
-    return MD5(key)
+    let fileExtension = URL(fileURLWithPath: key).pathExtension
+    let fileName = MD5(key)
+
+    switch fileExtension.isEmpty {
+    case true:
+      return fileName
+    case false:
+      return "\(fileName).\(fileExtension)"
+    }
   }
 
   /**

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -92,6 +92,15 @@ final class DiskStorageTests: XCTestCase {
     XCTAssertEqual(entry?.expiry.date, expiry.date)
   }
 
+  func testCacheEntryPath() throws {
+    let key = "test.mp4"
+    try storage.setObject(testObject, forKey: key)
+    let entry = try storage.entry(forKey: key)
+    let filePath = storage.makeFilePath(for: key)
+
+    XCTAssertEqual(entry.filePath, filePath)
+  }
+
   /// Test that it resolves cached object
   func testSetObject() throws {
     try storage.setObject(testObject, forKey: key)
@@ -198,6 +207,7 @@ final class DiskStorageTests: XCTestCase {
   /// Test that it returns a correct file name
   func testMakeFileName() {
     XCTAssertEqual(storage.makeFileName(for: key), MD5(key))
+    XCTAssertEqual(storage.makeFileName(for: "test.mp4"), "\(MD5("test.mp4")).mp4")
   }
 
   /// Test that it returns a correct file path


### PR DESCRIPTION
This pull request changes the way we build file name for cached objects in order to keep file extension if it's present in the cache key.

Fixes https://github.com/hyperoslo/Cache/issues/204