### PR TITLE
Adding the functionality to retrieve all the entries under a storage.

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12F4A066214538040099B9EC /* AllEntriesFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F4A065214538040099B9EC /* AllEntriesFinder.swift */; };
 		BDEDD37D1DBCEB8A007416A6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDEDD3561DBCE5B1007416A6 /* Cache.framework */; };
 		D21B667C1F6A723C00125DE1 /* DataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98531F694FFA00CE8F68 /* DataSerializer.swift */; };
 		D21B667E1F6A723C00125DE1 /* ExpirationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98551F694FFA00CE8F68 /* ExpirationMode.swift */; };
@@ -173,6 +174,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		12F4A065214538040099B9EC /* AllEntriesFinder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllEntriesFinder.swift; sourceTree = "<group>"; };
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D221E5BB20D00D9300BC940E /* MemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 		D2CF985A1F694FFA00CE8F68 /* Storage */ = {
 			isa = PBXGroup;
 			children = (
+				12F4A065214538040099B9EC /* AllEntriesFinder.swift */,
 				D221E5BB20D00D9300BC940E /* MemoryStorage.swift */,
 				D221E5C320D00DDB00BC940E /* DiskStorage.swift */,
 				D270147320D101F3003B45C7 /* StorageAware.swift */,
@@ -954,6 +957,7 @@
 				D2CF98681F694FFA00CE8F68 /* ImageWrapper.swift in Sources */,
 				D5A9D1C321144B65005DBD3F /* StorageObservationRegistry.swift in Sources */,
 				D2CF98871F695B8F00CE8F68 /* Types.swift in Sources */,
+				12F4A066214538040099B9EC /* AllEntriesFinder.swift in Sources */,
 				D2CF98621F694FFA00CE8F68 /* Date+Extensions.swift in Sources */,
 				D2CF98641F694FFA00CE8F68 /* DataSerializer.swift in Sources */,
 				D270147420D101F3003B45C7 /* StorageAware.swift in Sources */,

--- a/Source/Shared/Storage/AllEntriesFinder.swift
+++ b/Source/Shared/Storage/AllEntriesFinder.swift
@@ -1,0 +1,32 @@
+//
+//  AllEntriesFinder.swift
+//  Cache-iOS
+//
+//  Created by dushantsw on 2018-09-09.
+//  Copyright © 2018 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation
+
+/// A protocol user for load all the entries and objects
+protocol AllEntriesRetriever {
+  associatedtype T
+
+  /**
+   Loads all the entries from the disk cache. It does not
+   load or store entries on retrieval into memory as sync
+   issues may occur.
+   - Returns: An array of Entry for associated type T
+   */
+  func entries() throws -> [Entry<T>]
+}
+
+extension AllEntriesRetriever {
+  /**
+   Loads all the entries and extracts all the non-nil objects
+   - Returns: An array
+   */
+  func objects() throws -> [T] {
+    return try entries().compactMap({ $0.object })
+  }
+}

--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -25,6 +25,12 @@ public final class HybridStorage<T> {
   }
 }
 
+extension HybridStorage: AllEntriesRetriever {
+  func entries() throws -> [Entry<T>] {
+    return try diskStorage.entries()
+  }
+}
+
 extension HybridStorage: StorageAware {
   public func entry(forKey key: String) throws -> Entry<T> {
     do {
@@ -109,7 +115,7 @@ extension HybridStorage: StorageObservationRegistry {
       self?.storageObservations.removeValue(forKey: id)
     }
   }
-  
+
   public func removeAllStorageObservers() {
     storageObservations.removeAll()
   }
@@ -155,7 +161,7 @@ extension HybridStorage: KeyObservationRegistry {
   }
 
   private func notifyObserver(about change: KeyChange<T>, whereKey closure: ((String) -> Bool)) {
-    let observation = keyObservations.first { key, value in closure(key) }?.value
+    let observation = keyObservations.first { key, _ in closure(key) }?.value
     observation?(self, change)
   }
 

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -42,6 +42,12 @@ public final class Storage<T> {
   public lazy var async = self.asyncStorage
 }
 
+extension Storage: AllEntriesRetriever {
+  func entries() throws -> [Entry<T>] {
+    return try self.syncStorage.entries()
+  }
+}
+
 extension Storage: StorageAware {
   public func entry(forKey key: String) throws -> Entry<T> {
     return try self.syncStorage.entry(forKey: key)
@@ -94,7 +100,7 @@ extension Storage: KeyObservationRegistry {
     forKey key: String,
     closure: @escaping (O, Storage, KeyChange<T>) -> Void
   ) -> ObservationToken {
-    return hybridStorage.addObserver(observer, forKey: key) { [weak self] observer, _ , change in
+    return hybridStorage.addObserver(observer, forKey: key) { [weak self] observer, _, change in
       guard let strongSelf = self else { return }
       closure(observer, strongSelf, change)
     }

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -13,6 +13,16 @@ public class SyncStorage<T> {
   }
 }
 
+extension SyncStorage: AllEntriesRetriever {
+  func entries() throws -> [Entry<T>] {
+    var entries: [Entry<T>] = []
+    try serialQueue.sync {
+        entries = try innerStorage.entries()
+    }
+    return entries
+  }
+}
+
 extension SyncStorage: StorageAware {
   public func entry(forKey key: String) throws -> Entry<T> {
     var entry: Entry<T>!

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -5,6 +5,7 @@ import Dispatch
 final class AsyncStorageTests: XCTestCase {
   private var storage: AsyncStorage<User>!
   let user = User(firstName: "John", lastName: "Snow")
+  let userTwo = User(firstName: "Jamie", lastName: "Lannister")
 
   override func setUp() {
     super.setUp()
@@ -32,6 +33,26 @@ final class AsyncStorageTests: XCTestCase {
         XCTFail()
       }
     })
+
+    wait(for: [expectation], timeout: 1)
+  }
+
+  func testGettingObjects() throws {
+    let expectation = self.expectation(description: #function)
+
+    storage.setObject(user, forKey: user.firstName, completion: { _ in })
+    storage.setObject(userTwo, forKey: userTwo.firstName, completion: { _ in })
+    storage.objects { result in
+      switch result {
+      case .value(let users):
+        XCTAssertEqual(users.count, 2)
+        XCTAssertTrue(users.contains(self.user))
+        XCTAssertTrue(users.contains(self.userTwo))
+        expectation.fulfill()
+      default:
+        XCTFail()
+      }
+    }
 
     wait(for: [expectation], timeout: 1)
   }

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -91,6 +91,25 @@ final class DiskStorageTests: XCTestCase {
     XCTAssertEqual(entry?.object.lastName, testObject.lastName)
     XCTAssertEqual(entry?.expiry.date, expiry.date)
   }
+    
+  func testEntries() throws {
+    // Store multiple entries
+    let userOne = User(firstName: "First", lastName: "Something")
+    let userTwo = User(firstName: "Second", lastName: "Something")
+    try storage.setObject(userOne, forKey: "First")
+    try storage.setObject(userTwo, forKey: "Second")
+    
+    // Retrieve all
+    let entries: [Entry<User>] = try storage.entries()
+    
+    // Assert
+    XCTAssertNotNil(entries)
+    XCTAssertEqual(entries.count, 2)
+    
+    let users = entries.compactMap({ $0.object })
+    XCTAssertTrue(users.contains(userOne))
+    XCTAssertTrue(users.contains(userTwo))
+  }
 
   func testCacheEntryPath() throws {
     let key = "test.mp4"

--- a/Tests/iOS/Tests/Storage/HybridStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/HybridStorageTests.swift
@@ -4,7 +4,9 @@ import XCTest
 final class HybridStorageTests: XCTestCase {
   private let cacheName = "WeirdoCache"
   private let key = "alongweirdkey"
+  private let keyTwo = "secondweirdokey"
   private let testObject = User(firstName: "John", lastName: "Targaryen")
+  private let testObjectTwo = User(firstName: "Jon", lastName: "Snow")
   private var storage: HybridStorage<User>!
   private let fileManager = FileManager()
 
@@ -46,6 +48,15 @@ final class HybridStorageTests: XCTestCase {
 
     XCTAssertEqual(entry.object, testObject)
     XCTAssertEqual(entry.expiry.date, expiryDate)
+  }
+    
+  func testEntries() throws {
+    try storage.setObject(testObject, forKey: key)
+    try storage.setObject(testObjectTwo, forKey: keyTwo)
+    
+    let entries = try storage.entries()
+    XCTAssertEqual(entries.count, 2)
+    XCTAssertTrue(entries.contains(where: { $0.object == testObjectTwo} ))
   }
 
   /// Should resolve from disk and set in-memory cache if object not in-memory

--- a/Tests/iOS/Tests/Storage/SyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/SyncStorageTests.swift
@@ -5,6 +5,7 @@ import Dispatch
 final class SyncStorageTests: XCTestCase {
   private var storage: SyncStorage<User>!
   let user = User(firstName: "John", lastName: "Snow")
+  let userTwo = User(firstName: "Job", lastName: "Thatcher")
 
   override func setUp() {
     super.setUp()
@@ -26,6 +27,21 @@ final class SyncStorageTests: XCTestCase {
     let cachedObject = try storage.object(forKey: "user")
 
     XCTAssertEqual(cachedObject, user)
+  }
+  
+  func testSetObjects() throws {
+    try storage.setObject(user, forKey: "john")
+    try storage.setObject(userTwo, forKey: "job")
+    
+    let objects = try storage.objects()
+    XCTAssertEqual(objects.count, 2)
+    XCTAssertTrue(objects.contains(userTwo))
+    XCTAssertTrue(objects.contains(user))
+  }
+  
+  func testSetObjects_EmptyEntries() throws {
+    let objects = try storage.objects()
+    XCTAssertEqual(objects.count, 0)
   }
 
   func testRemoveAll() throws {


### PR DESCRIPTION
Functional:
- Expanded the functionality to retrieve all the entries under a storage.

Non-Functional:
- Fixed issues mentioned by Swift lint

P.S! The max storage limit might differ between disk and memory config. Therefore, added support to retrieve all only from disk.