### PR TITLE
Fix capitalization of `Async APIs` in `Table of Contents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   * [Storage](#storage)
   * [Configuration](#configuration)
   * [Sync APIs](#sync-apis)
-  * [Async APIS](#async-apis)
+  * [Async APIs](#async-apis)
   * [Expiry date](#expiry-date)
 * [Observations](#observations)
   * [Storage observations](#storage-observations)


### PR DESCRIPTION
This PR is a single character change for the readme file. 

The `Async APIs` link in the Table of Contents had the `s` capitalized while the `Sync APIs` was lowercase.