### PR TITLE
Avoid loading disk content to memory when calling existsObject

### DIFF
--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -81,6 +81,11 @@ extension DiskStorage: StorageAware {
     _ = fileManager.createFile(atPath: filePath, contents: data, attributes: nil)
     try fileManager.setAttributes([.modificationDate: expiry.date], ofItemAtPath: filePath)
   }
+    
+  public func existsObject(forKey key: String) throws -> Bool {
+    let filePath = makeFilePath(for: key)
+    return fileManager.fileExists(atPath: filePath)
+  }
 
   public func removeObject(forKey key: String) throws {
     let filePath = makeFilePath(for: key)

--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -61,6 +61,15 @@ extension HybridStorage: StorageAware {
     notifyStorageObservers(about: .add(key: key))
   }
 
+  public func existsObject(forKey key: String) throws -> Bool {
+    do {
+      return try memoryStorage.existsObject(forKey: key) ||
+             diskStorage.existsObject(forKey: key)
+    } catch {
+      return false
+    }
+  }
+
   public func removeAll() throws {
     memoryStorage.removeAll()
     try diskStorage.removeAll()

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -20,6 +20,10 @@ extension MemoryStorage {
     cache.setObject(capsule, forKey: NSString(string: key))
     keys.insert(key)
   }
+  
+  public func existsObject(forKey key: String) throws -> Bool {
+    return cache.object(forKey: NSString(string: key)) != nil
+  }
 
   public func removeAll() {
     cache.removeAllObjects()

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -54,7 +54,11 @@ extension Storage: StorageAware {
   public func setObject(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
     try self.syncStorage.setObject(object, forKey: key, expiry: expiry)
   }
-
+  
+  public func existsObject(forKey key: String) throws -> Bool {
+    return try self.syncStorage.existsObject(forKey: key)
+  }
+  
   public func removeAll() throws {
     try self.syncStorage.removeAll()
   }

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -58,16 +58,7 @@ public extension StorageAware {
   func object(forKey key: String) throws -> T {
     return try entry(forKey: key).object
   }
-
-  func existsObject(forKey key: String) throws -> Bool {
-    do {
-      let _: T = try object(forKey: key)
-      return true
-    } catch {
-      return false
-    }
-  }
-
+  
   func isExpiredObject(forKey key: String) throws -> Bool {
     do {
       let entry = try self.entry(forKey: key)

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -35,6 +35,14 @@ extension SyncStorage: StorageAware {
     }
   }
 
+  public func existsObject(forKey key: String) throws -> Bool {
+    var entry: Bool!
+    try serialQueue.sync {
+      entry = try innerStorage.existsObject(forKey: key)
+    }
+    return entry
+  }
+
   public func removeAll() throws {
     try serialQueue.sync {
       try innerStorage.removeAll()


### PR DESCRIPTION
`StorageAware` extensions provided `existsObject()` method which was nice and simple way to provide implementation for all `StorageAware` types out of the box. However using it causes `DiskStorage` to load content form disk into memory.

This PR provided explicit implementation for all `StorageAware` types. In case of `DiskStorage` it only checks if file exists on the file system without loading the content.

**Rationale:**

When you're caching hundreds of items (each being few or more megabytes) and you're using `existsObject()` on some point of the app lifetime to check if items are cached or not OS may kill your app because due to running OOM. Even if you're doing the check asynchronously in serial manner ARC may not release memory allocations on time causing memory usage to skyrocket.