### PR TITLE
Allow Storage to use any hashable key

### DIFF
--- a/Cache.xcodeproj/project.pbxproj
+++ b/Cache.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E79164A250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E791649250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift */; };
+		0E79164B250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E791649250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift */; };
+		0E79164C250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E791649250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift */; };
+		0E79164E250E2B0400A71666 /* Hasher+constantAccrossExecutions+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E79164D250E2B0400A71666 /* Hasher+constantAccrossExecutions+Tests.swift */; };
 		BDEDD37D1DBCEB8A007416A6 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDEDD3561DBCE5B1007416A6 /* Cache.framework */; };
 		D21B667C1F6A723C00125DE1 /* DataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98531F694FFA00CE8F68 /* DataSerializer.swift */; };
 		D21B667E1F6A723C00125DE1 /* ExpirationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CF98551F694FFA00CE8F68 /* ExpirationMode.swift */; };
@@ -173,6 +177,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0E791649250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Hasher+constantAccrossExecutions.swift"; sourceTree = "<group>"; };
+		0E79164D250E2B0400A71666 /* Hasher+constantAccrossExecutions+Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Hasher+constantAccrossExecutions+Tests.swift"; sourceTree = "<group>"; };
 		BDEDD3561DBCE5B1007416A6 /* Cache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDEDD3781DBCEB8A007416A6 /* Cache-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cache-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D221E5BB20D00D9300BC940E /* MemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
@@ -323,6 +329,7 @@
 		D2CF984F1F694FFA00CE8F68 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				0E791649250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift */,
 				D28897041F8B79B300C61DEE /* JSONDecoder+Extensions.swift */,
 				D2CF98501F694FFA00CE8F68 /* Date+Extensions.swift */,
 			);
@@ -384,6 +391,7 @@
 			isa = PBXGroup;
 			children = (
 				D2CF98721F69513800CE8F68 /* Date+ExtensionsTests.swift */,
+				0E79164D250E2B0400A71666 /* Hasher+constantAccrossExecutions+Tests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -803,6 +811,7 @@
 				D270147E20D107DA003B45C7 /* SyncStorage.swift in Sources */,
 				D292DAFF1F6A970B0060F614 /* Result.swift in Sources */,
 				D21B669A1F6A724300125DE1 /* Date+Extensions.swift in Sources */,
+				0E79164C250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift in Sources */,
 				D21B66891F6A723C00125DE1 /* ImageWrapper.swift in Sources */,
 				D21B668B1F6A723C00125DE1 /* StorageError.swift in Sources */,
 				D5A9D1B921134547005DBD3F /* ObservationToken.swift in Sources */,
@@ -848,6 +857,7 @@
 				D2CF987C1F69513800CE8F68 /* Date+ExtensionsTests.swift in Sources */,
 				D28C9BAC1F67ECD400C180C1 /* TestHelper+iOS.swift in Sources */,
 				D2CF98211F69427C00CE8F68 /* TestHelper.swift in Sources */,
+				0E79164E250E2B0400A71666 /* Hasher+constantAccrossExecutions+Tests.swift in Sources */,
 				D511464F21147B7C00197DCE /* ObservationTokenTests.swift in Sources */,
 				D2CF987F1F69513800CE8F68 /* ImageWrapperTests.swift in Sources */,
 				D2D4CC1A1FA3166900E4A2D5 /* MD5Tests.swift in Sources */,
@@ -889,6 +899,7 @@
 				D270147D20D107DA003B45C7 /* SyncStorage.swift in Sources */,
 				D292DAFE1F6A970B0060F614 /* Result.swift in Sources */,
 				D21B66991F6A724200125DE1 /* Date+Extensions.swift in Sources */,
+				0E79164B250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift in Sources */,
 				D21B66801F6A723C00125DE1 /* ImageWrapper.swift in Sources */,
 				D21B66821F6A723C00125DE1 /* StorageError.swift in Sources */,
 				D5A9D1B821134547005DBD3F /* ObservationToken.swift in Sources */,
@@ -942,6 +953,7 @@
 				D2D4CC241FA3426B00E4A2D5 /* JSONArrayWrapper.swift in Sources */,
 				D270147C20D107DA003B45C7 /* SyncStorage.swift in Sources */,
 				D2CF98671F694FFA00CE8F68 /* Expiry.swift in Sources */,
+				0E79164A250E2AA500A71666 /* Hasher+constantAccrossExecutions.swift in Sources */,
 				D270148820D11040003B45C7 /* Storage+Transform.swift in Sources */,
 				D2CF986A1F694FFA00CE8F68 /* StorageError.swift in Sources */,
 				D5A9D1B721134547005DBD3F /* ObservationToken.swift in Sources */,

--- a/Source/Shared/Extensions/Hasher+constantAccrossExecutions.swift
+++ b/Source/Shared/Extensions/Hasher+constantAccrossExecutions.swift
@@ -1,0 +1,26 @@
+
+import Foundation
+
+extension Hasher {
+    // Stolen from https://github.com/apple/swift/blob/master/stdlib/public/core/SipHash.swift
+    // in order to replicate the exact format in bytes
+    private struct _State {
+      private var v0: UInt64 = 0x736f6d6570736575
+      private var v1: UInt64 = 0x646f72616e646f6d
+      private var v2: UInt64 = 0x6c7967656e657261
+      private var v3: UInt64 = 0x7465646279746573
+      private var v4: UInt64 = 0
+      private var v5: UInt64 = 0
+      private var v6: UInt64 = 0
+      private var v7: UInt64 = 0
+    }
+
+    static func constantAccrossExecutions() -> Hasher {
+        let offset = MemoryLayout<Hasher>.size - MemoryLayout<_State>.size
+        var hasher = Hasher()
+        withUnsafeMutableBytes(of: &hasher) { pointer in
+            pointer.baseAddress!.storeBytes(of: _State(), toByteOffset: offset, as: _State.self)
+        }
+        return hasher
+    }
+}

--- a/Source/Shared/Library/ImageWrapper.swift
+++ b/Source/Shared/Library/ImageWrapper.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if os(iOS) || os(tvOS) || os(macOS)
 public struct ImageWrapper: Codable {
   public let image: Image
 
@@ -30,3 +31,4 @@ public struct ImageWrapper: Codable {
     try container.encode(data, forKey: CodingKeys.image)
   }
 }
+#endif

--- a/Source/Shared/Library/TransformerFactory.swift
+++ b/Source/Shared/Library/TransformerFactory.swift
@@ -9,6 +9,7 @@ public class TransformerFactory {
     return Transformer<Data>(toData: toData, fromData: fromData)
   }
 
+  #if os(iOS) || os(tvOS) || os(macOS)
   public static func forImage() -> Transformer<Image> {
     let toData: (Image) throws -> Data = { image in
       return try image.cache_toData().unwrapOrThrow(error: StorageError.transformerFail)
@@ -20,6 +21,7 @@ public class TransformerFactory {
 
     return Transformer<Image>(toData: toData, fromData: fromData)
   }
+  #endif
 
   public static func forCodable<U: Codable>(ofType: U.Type) -> Transformer<U> {
     let toData: (U) throws -> Data = { object in

--- a/Source/Shared/Storage/KeyObservationRegistry.swift
+++ b/Source/Shared/Storage/KeyObservationRegistry.swift
@@ -15,15 +15,15 @@ public protocol KeyObservationRegistry {
   @discardableResult
   func addObserver<O: AnyObject>(
     _ observer: O,
-    forKey key: String,
-    closure: @escaping (O, S, KeyChange<S.T>) -> Void
+    forKey key: S.Key,
+    closure: @escaping (O, S, KeyChange<S.Value>) -> Void
   ) -> ObservationToken
 
   /**
    Removes observer by the given key.
    - Parameter key: Unique key to identify the object in the cache
    */
-  func removeObserver(forKey key: String)
+  func removeObserver(forKey key: S.Key)
 
   /// Removes all registered key observers
   func removeAllKeyObservers()

--- a/Source/Shared/Storage/MemoryStorage.swift
+++ b/Source/Shared/Storage/MemoryStorage.swift
@@ -1,9 +1,25 @@
 import Foundation
 
-public class MemoryStorage<T>: StorageAware {
-  fileprivate let cache = NSCache<NSString, MemoryCapsule>()
+public class MemoryStorage<Key: Hashable, Value>: StorageAware {
+  final class WrappedKey: NSObject {
+    let key: Key
+
+    init(_ key: Key) { self.key = key }
+
+    override var hash: Int { return key.hashValue }
+
+    override func isEqual(_ object: Any?) -> Bool {
+      guard let value = object as? WrappedKey else {
+        return false
+      }
+
+      return value.key == key
+    }
+  }
+
+  fileprivate let cache = NSCache<WrappedKey, MemoryCapsule>()
   // Memory cache keys
-  fileprivate var keys = Set<String>()
+  fileprivate var keys = Set<Key>()
   /// Configuration
   fileprivate let config: MemoryConfig
 
@@ -15,9 +31,9 @@ public class MemoryStorage<T>: StorageAware {
 }
 
 extension MemoryStorage {
-  public func setObject(_ object: T, forKey key: String, expiry: Expiry? = nil) {
+  public func setObject(_ object: Value, forKey key: Key, expiry: Expiry? = nil) {
     let capsule = MemoryCapsule(value: object, expiry: .date(expiry?.date ?? config.expiry.date))
-    cache.setObject(capsule, forKey: NSString(string: key))
+    cache.setObject(capsule, forKey: WrappedKey(key))
     keys.insert(key)
   }
 
@@ -33,23 +49,23 @@ extension MemoryStorage {
     }
   }
 
-  public func removeObjectIfExpired(forKey key: String) {
-    if let capsule = cache.object(forKey: NSString(string: key)), capsule.expiry.isExpired {
+  public func removeObjectIfExpired(forKey key: Key) {
+    if let capsule = cache.object(forKey: WrappedKey(key)), capsule.expiry.isExpired {
       removeObject(forKey: key)
     }
   }
 
-  public func removeObject(forKey key: String) {
-    cache.removeObject(forKey: NSString(string: key))
+  public func removeObject(forKey key: Key) {
+    cache.removeObject(forKey: WrappedKey(key))
     keys.remove(key)
   }
 
-  public func entry(forKey key: String) throws -> Entry<T> {
-    guard let capsule = cache.object(forKey: NSString(string: key)) else {
+  public func entry(forKey key: Key) throws -> Entry<Value> {
+    guard let capsule = cache.object(forKey: WrappedKey(key)) else {
       throw StorageError.notFound
     }
 
-    guard let object = capsule.object as? T else {
+    guard let object = capsule.object as? Value else {
       throw StorageError.typeNotMatch
     }
 
@@ -58,8 +74,8 @@ extension MemoryStorage {
 }
 
 public extension MemoryStorage {
-  func transform<U>() -> MemoryStorage<U> {
-    let storage = MemoryStorage<U>(config: config)
+  func transform<U>() -> MemoryStorage<Key, U> {
+    let storage = MemoryStorage<Key, U>(config: config)
     return storage
   }
 }

--- a/Source/Shared/Storage/Storage+Transform.swift
+++ b/Source/Shared/Storage/Storage+Transform.swift
@@ -6,10 +6,13 @@ public extension Storage {
     return storage
   }
 
+
+  #if os(iOS) || os(tvOS) || os(macOS)
   func transformImage() -> Storage<Key, Image> {
     let storage = transform(transformer: TransformerFactory.forImage())
     return storage
   }
+  #endif
 
   func transformCodable<U: Codable>(ofType: U.Type) -> Storage<Key, U> {
     let storage = transform(transformer: TransformerFactory.forCodable(ofType: U.self))

--- a/Source/Shared/Storage/Storage+Transform.swift
+++ b/Source/Shared/Storage/Storage+Transform.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 public extension Storage {
-  func transformData() -> Storage<Data> {
+  func transformData() -> Storage<Key, Data> {
     let storage = transform(transformer: TransformerFactory.forData())
     return storage
   }
 
-  func transformImage() -> Storage<Image> {
+  func transformImage() -> Storage<Key, Image> {
     let storage = transform(transformer: TransformerFactory.forImage())
     return storage
   }
 
-  func transformCodable<U: Codable>(ofType: U.Type) -> Storage<U> {
+  func transformCodable<U: Codable>(ofType: U.Type) -> Storage<Key, U> {
     let storage = transform(transformer: TransformerFactory.forCodable(ofType: U.self))
     return storage
   }

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -3,11 +3,11 @@ import Dispatch
 
 /// Manage storage. Use memory storage if specified.
 /// Synchronous by default. Use `async` for asynchronous operations.
-public final class Storage<T> {
+public final class Storage<Key: Hashable, Value> {
   /// Used for sync operations
-  private let syncStorage: SyncStorage<T>
-  private let asyncStorage: AsyncStorage<T>
-  private let hybridStorage: HybridStorage<T>
+  private let syncStorage: SyncStorage<Key, Value>
+  private let asyncStorage: AsyncStorage<Key, Value>
+  private let hybridStorage: HybridStorage<Key, Value>
 
   /// Initialize storage with configuration options.
   ///
@@ -15,9 +15,9 @@ public final class Storage<T> {
   ///   - diskConfig: Configuration for disk storage
   ///   - memoryConfig: Optional. Pass config if you want memory cache
   /// - Throws: Throw StorageError if any.
-  public convenience init(diskConfig: DiskConfig, memoryConfig: MemoryConfig, transformer: Transformer<T>) throws {
-    let disk = try DiskStorage(config: diskConfig, transformer: transformer)
-    let memory = MemoryStorage<T>(config: memoryConfig)
+  public convenience init(diskConfig: DiskConfig, memoryConfig: MemoryConfig, transformer: Transformer<Value>) throws {
+    let disk = try DiskStorage<Key, Value>(config: diskConfig, transformer: transformer)
+    let memory = MemoryStorage<Key, Value>(config: memoryConfig)
     let hybridStorage = HybridStorage(memoryStorage: memory, diskStorage: disk)
     self.init(hybridStorage: hybridStorage)
   }
@@ -26,7 +26,7 @@ public final class Storage<T> {
   ///
   /// - Parameter syncStorage: Synchronous storage
   /// - Paraeter: asyncStorage: Asynchronous storage
-  public init(hybridStorage: HybridStorage<T>) {
+  public init(hybridStorage: HybridStorage<Key, Value>) {
     self.hybridStorage = hybridStorage
     self.syncStorage = SyncStorage(
       storage: hybridStorage,
@@ -43,15 +43,15 @@ public final class Storage<T> {
 }
 
 extension Storage: StorageAware {
-  public func entry(forKey key: String) throws -> Entry<T> {
+  public func entry(forKey key: Key) throws -> Entry<Value> {
     return try self.syncStorage.entry(forKey: key)
   }
 
-  public func removeObject(forKey key: String) throws {
+  public func removeObject(forKey key: Key) throws {
     try self.syncStorage.removeObject(forKey: key)
   }
 
-  public func setObject(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
+  public func setObject(_ object: Value, forKey key: Key, expiry: Expiry? = nil) throws {
     try self.syncStorage.setObject(object, forKey: key, expiry: expiry)
   }
 
@@ -65,8 +65,8 @@ extension Storage: StorageAware {
 }
 
 public extension Storage {
-  func transform<U>(transformer: Transformer<U>) -> Storage<U> {
-    return Storage<U>(hybridStorage: hybridStorage.transform(transformer: transformer))
+  func transform<U>(transformer: Transformer<U>) -> Storage<Key, U> {
+    return Storage<Key, U>(hybridStorage: hybridStorage.transform(transformer: transformer))
   }
 }
 
@@ -74,7 +74,7 @@ extension Storage: StorageObservationRegistry {
   @discardableResult
   public func addStorageObserver<O: AnyObject>(
     _ observer: O,
-    closure: @escaping (O, Storage, StorageChange) -> Void
+    closure: @escaping (O, Storage, StorageChange<Key>) -> Void
   ) -> ObservationToken {
     return hybridStorage.addStorageObserver(observer) { [weak self] observer, _, change in
       guard let strongSelf = self else { return }
@@ -91,8 +91,8 @@ extension Storage: KeyObservationRegistry {
   @discardableResult
   public func addObserver<O: AnyObject>(
     _ observer: O,
-    forKey key: String,
-    closure: @escaping (O, Storage, KeyChange<T>) -> Void
+    forKey key: Key,
+    closure: @escaping (O, Storage, KeyChange<Value>) -> Void
   ) -> ObservationToken {
     return hybridStorage.addObserver(observer, forKey: key) { [weak self] observer, _, change in
       guard let strongSelf = self else { return }
@@ -100,7 +100,7 @@ extension Storage: KeyObservationRegistry {
     }
   }
 
-  public func removeObserver(forKey key: String) {
+  public func removeObserver(forKey key: Key) {
     hybridStorage.removeObserver(forKey: key)
   }
 

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -2,26 +2,27 @@ import Foundation
 
 /// A protocol used for saving and loading from storage
 public protocol StorageAware {
-  associatedtype T
+  associatedtype Key: Hashable
+  associatedtype Value
   /**
    Tries to retrieve the object from the storage.
    - Parameter key: Unique key to identify the object in the cache
    - Returns: Cached object or nil if not found
    */
-  func object(forKey key: String) throws -> T
+  func object(forKey key: Key) throws -> Value
 
   /**
    Get cache entry which includes object with metadata.
    - Parameter key: Unique key to identify the object in the cache
    - Returns: Object wrapper with metadata or nil if not found
    */
-  func entry(forKey key: String) throws -> Entry<T>
+  func entry(forKey key: Key) throws -> Entry<Value>
 
   /**
    Removes the object by the given key.
    - Parameter key: Unique key to identify the object.
    */
-  func removeObject(forKey key: String) throws
+  func removeObject(forKey key: Key) throws
 
   /**
    Saves passed object.
@@ -29,13 +30,13 @@ public protocol StorageAware {
    - Parameter object: Object that needs to be cached.
    - Parameter expiry: Overwrite expiry for this object only.
    */
-  func setObject(_ object: T, forKey key: String, expiry: Expiry?) throws
+  func setObject(_ object: Value, forKey key: Key, expiry: Expiry?) throws
 
   /**
    Check if an object exist by the given key.
    - Parameter key: Unique key to identify the object.
    */
-  func existsObject(forKey key: String) throws -> Bool
+  func existsObject(forKey key: Key) throws -> Bool
 
   /**
    Removes all objects from the cache storage.
@@ -51,24 +52,24 @@ public protocol StorageAware {
    Check if an expired object by the given key.
    - Parameter key: Unique key to identify the object.
    */
-  func isExpiredObject(forKey key: String) throws -> Bool
+  func isExpiredObject(forKey key: Key) throws -> Bool
 }
 
 public extension StorageAware {
-  func object(forKey key: String) throws -> T {
+  func object(forKey key: Key) throws -> Value {
     return try entry(forKey: key).object
   }
 
-  func existsObject(forKey key: String) throws -> Bool {
+  func existsObject(forKey key: Key) throws -> Bool {
     do {
-      let _: T = try object(forKey: key)
+      let _: Value = try object(forKey: key)
       return true
     } catch {
       return false
     }
   }
 
-  func isExpiredObject(forKey key: String) throws -> Bool {
+  func isExpiredObject(forKey key: Key) throws -> Bool {
     do {
       let entry = try self.entry(forKey: key)
       return entry.expiry.isExpired

--- a/Source/Shared/Storage/StorageObservationRegistry.swift
+++ b/Source/Shared/Storage/StorageObservationRegistry.swift
@@ -14,7 +14,7 @@ public protocol StorageObservationRegistry {
   @discardableResult
   func addStorageObserver<O: AnyObject>(
     _ observer: O,
-    closure: @escaping (O, S, StorageChange) -> Void
+    closure: @escaping (O, S, StorageChange<S.Key>) -> Void
   ) -> ObservationToken
 
   /// Removes all registered key observers
@@ -23,14 +23,14 @@ public protocol StorageObservationRegistry {
 
 // MARK: - StorageChange
 
-public enum StorageChange: Equatable {
-  case add(key: String)
-  case remove(key: String)
+public enum StorageChange<Key: Hashable>: Equatable {
+  case add(key: Key)
+  case remove(key: Key)
   case removeAll
   case removeExpired
 }
 
-public func == (lhs: StorageChange, rhs: StorageChange) -> Bool {
+public func == <Key : Hashable>(lhs: StorageChange<Key>, rhs: StorageChange<Key>) -> Bool {
   switch (lhs, rhs) {
   case (.add(let key1), .add(let key2)), (.remove(let key1), .remove(let key2)):
     return key1 == key2

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -3,19 +3,19 @@ import Dispatch
 
 /// Manipulate storage in a "all sync" manner.
 /// Block the current queue until the operation completes.
-public class SyncStorage<T> {
-  public let innerStorage: HybridStorage<T>
+public class SyncStorage<Key: Hashable, Value> {
+  public let innerStorage: HybridStorage<Key, Value>
   public let serialQueue: DispatchQueue
 
-  public init(storage: HybridStorage<T>, serialQueue: DispatchQueue) {
+  public init(storage: HybridStorage<Key, Value>, serialQueue: DispatchQueue) {
     self.innerStorage = storage
     self.serialQueue = serialQueue
   }
 }
 
 extension SyncStorage: StorageAware {
-  public func entry(forKey key: String) throws -> Entry<T> {
-    var entry: Entry<T>!
+  public func entry(forKey key: Key) throws -> Entry<Value> {
+    var entry: Entry<Value>!
     try serialQueue.sync {
       entry = try innerStorage.entry(forKey: key)
     }
@@ -23,13 +23,13 @@ extension SyncStorage: StorageAware {
     return entry
   }
 
-  public func removeObject(forKey key: String) throws {
+  public func removeObject(forKey key: Key) throws {
     try serialQueue.sync {
       try self.innerStorage.removeObject(forKey: key)
     }
   }
 
-  public func setObject(_ object: T, forKey key: String, expiry: Expiry? = nil) throws {
+  public func setObject(_ object: Value, forKey key: Key, expiry: Expiry? = nil) throws {
     try serialQueue.sync {
       try innerStorage.setObject(object, forKey: key, expiry: expiry)
     }
@@ -49,8 +49,8 @@ extension SyncStorage: StorageAware {
 }
 
 public extension SyncStorage {
-  func transform<U>(transformer: Transformer<U>) -> SyncStorage<U> {
-    let storage = SyncStorage<U>(
+  func transform<U>(transformer: Transformer<U>) -> SyncStorage<Key, U> {
+    let storage = SyncStorage<Key, U>(
       storage: innerStorage.transform(transformer: transformer),
       serialQueue: serialQueue
     )

--- a/Tests/Mac/Helpers/NSImage+ExtensionsTests.swift
+++ b/Tests/Mac/Helpers/NSImage+ExtensionsTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 @testable import Cache
 
@@ -14,3 +15,4 @@ extension NSImage {
       .representation(using: imageFileType, properties: [:])!
   }
 }
+#endif

--- a/Tests/Mac/Helpers/TestHelper+OSX.swift
+++ b/Tests/Mac/Helpers/TestHelper+OSX.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 extension TestHelper {
@@ -9,3 +10,4 @@ extension TestHelper {
     return image
   }
 }
+#endif

--- a/Tests/Shared/TestHelper.swift
+++ b/Tests/Shared/TestHelper.swift
@@ -19,7 +19,7 @@ struct TestHelper {
     #elseif os(tvOS)
     NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
     NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
-    #else
+    #elseif os(macOS)
     NotificationCenter.default.post(name: NSApplication.willTerminateNotification, object: nil)
     NotificationCenter.default.post(name: NSApplication.didResignActiveNotification, object: nil)
     #endif

--- a/Tests/iOS/Helpers/TestHelper+iOS.swift
+++ b/Tests/iOS/Helpers/TestHelper+iOS.swift
@@ -1,3 +1,4 @@
+#if os(iOS) || os(tvOS)
 import UIKit
 
 extension TestHelper {
@@ -14,3 +15,4 @@ extension TestHelper {
     return image!
   }
 }
+#endif

--- a/Tests/iOS/Helpers/UIImage+ExtensionsTests.swift
+++ b/Tests/iOS/Helpers/UIImage+ExtensionsTests.swift
@@ -1,3 +1,4 @@
+#if os(iOS) || os(tvOS)
 import UIKit
 
 extension UIImage {
@@ -24,3 +25,4 @@ extension UIImage {
     return drawnImage!.cgImage!.dataProvider!.data! as Data
   }
 }
+#endif

--- a/Tests/iOS/Tests/Extensions/Hasher+constantAccrossExecutions+Tests.swift
+++ b/Tests/iOS/Tests/Extensions/Hasher+constantAccrossExecutions+Tests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Cache
+
+final class HasherConstantAccrossExecutionsTests: XCTestCase {
+  func testHashValueRemainsTheSameAsLastTime() {
+    // Warning: this test may start failing after a Swift Update
+    let value = "some string with some values"
+    var hasher = Hasher.constantAccrossExecutions()
+    value.hash(into: &hasher)
+    XCTAssertEqual(hasher.finalize(), -4706942985426845298)
+  }
+}

--- a/Tests/iOS/Tests/Library/ObjectConverterTests.swift
+++ b/Tests/iOS/Tests/Library/ObjectConverterTests.swift
@@ -2,12 +2,12 @@ import XCTest
 @testable import Cache
 
 final class JSONDecoderExtensionsTests: XCTestCase {
-  private var storage: HybridStorage<User>!
+  private var storage: HybridStorage<String, User>!
 
   override func setUp() {
     super.setUp()
-    let memory = MemoryStorage<User>(config: MemoryConfig())
-    let disk = try! DiskStorage<User>(
+    let memory = MemoryStorage<String, User>(config: MemoryConfig())
+    let disk = try! DiskStorage<String, User>(
       config: DiskConfig(name: "HybridDisk"),
       transformer: TransformerFactory.forCodable(ofType: User.self)
     )

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -3,14 +3,14 @@ import Dispatch
 @testable import Cache
 
 final class AsyncStorageTests: XCTestCase {
-  private var storage: AsyncStorage<User>!
+  private var storage: AsyncStorage<String, User>!
   let user = User(firstName: "John", lastName: "Snow")
 
   override func setUp() {
     super.setUp()
-    let memory = MemoryStorage<User>(config: MemoryConfig())
-    let disk = try! DiskStorage<User>(config: DiskConfig(name: "Async Disk"), transformer: TransformerFactory.forCodable(ofType: User.self))
-    let hybrid = HybridStorage<User>(memoryStorage: memory, diskStorage: disk)
+    let memory = MemoryStorage<String, User>(config: MemoryConfig())
+    let disk = try! DiskStorage<String, User>(config: DiskConfig(name: "Async Disk"), transformer: TransformerFactory.forCodable(ofType: User.self))
+    let hybrid = HybridStorage<String, User>(memoryStorage: memory, diskStorage: disk)
     storage = AsyncStorage(storage: hybrid, serialQueue: DispatchQueue(label: "Async"))
   }
 

--- a/Tests/iOS/Tests/Storage/DiskStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/DiskStorageTests.swift
@@ -5,12 +5,12 @@ final class DiskStorageTests: XCTestCase {
   private let key = "youknownothing"
   private let testObject = User(firstName: "John", lastName: "Snow")
   private let fileManager = FileManager()
-  private var storage: DiskStorage<User>!
+  private var storage: DiskStorage<String, User>!
   private let config = DiskConfig(name: "Floppy")
 
   override func setUp() {
     super.setUp()
-    storage = try! DiskStorage<User>(config: config, transformer: TransformerFactory.forCodable(ofType: User.self))
+    storage = try! DiskStorage<String, User>(config: config, transformer: TransformerFactory.forCodable(ofType: User.self))
   }
 
   override func tearDown() {
@@ -47,7 +47,7 @@ final class DiskStorageTests: XCTestCase {
 
     let customConfig = DiskConfig(name: "SSD", directory: url)
 
-    storage = try DiskStorage<User>(config: customConfig, transformer: TransformerFactory.forCodable(ofType: User.self))
+    storage = try DiskStorage<String, User>(config: customConfig, transformer: TransformerFactory.forCodable(ofType: User.self))
 
     XCTAssertEqual(
       storage.path,

--- a/Tests/iOS/Tests/Storage/HybridStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/HybridStorageTests.swift
@@ -5,13 +5,13 @@ final class HybridStorageTests: XCTestCase {
   private let cacheName = "WeirdoCache"
   private let key = "alongweirdkey"
   private let testObject = User(firstName: "John", lastName: "Targaryen")
-  private var storage: HybridStorage<User>!
+  private var storage: HybridStorage<String, User>!
   private let fileManager = FileManager()
 
   override func setUp() {
     super.setUp()
-    let memory = MemoryStorage<User>(config: MemoryConfig())
-    let disk = try! DiskStorage<User>(config: DiskConfig(name: "HybridDisk"), transformer: TransformerFactory.forCodable(ofType: User.self))
+    let memory = MemoryStorage<String, User>(config: MemoryConfig())
+    let disk = try! DiskStorage<String, User>(config: DiskConfig(name: "HybridDisk"), transformer: TransformerFactory.forCodable(ofType: User.self))
 
     storage = HybridStorage(memoryStorage: memory, diskStorage: disk)
   }
@@ -160,7 +160,7 @@ final class HybridStorageTests: XCTestCase {
   // MARK: - Storage observers
 
   func testAddStorageObserver() throws {
-    var changes = [StorageChange]()
+    var changes = [StorageChange<String>]()
     storage.addStorageObserver(self) { _, _, change in
       changes.append(change)
     }

--- a/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/MemoryStorageTests.swift
@@ -4,12 +4,12 @@ import XCTest
 final class MemoryStorageTests: XCTestCase {
   private let key = "youknownothing"
   private let testObject = User(firstName: "John", lastName: "Snow")
-  private var storage: MemoryStorage<User>!
+  private var storage: MemoryStorage<String, User>!
   private let config = MemoryConfig(expiry: .never, countLimit: 10, totalCostLimit: 10)
 
   override func setUp() {
     super.setUp()
-    storage = MemoryStorage<User>(config: config)
+    storage = MemoryStorage<String, User>(config: config)
   }
 
   override func tearDown() {

--- a/Tests/iOS/Tests/Storage/StorageSupportTests.swift
+++ b/Tests/iOS/Tests/Storage/StorageSupportTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import Cache
 
 final class StorageSupportTests: XCTestCase {
-  private var storage: HybridStorage<Bool>!
+  private var storage: HybridStorage<String, Bool>!
 
   override func setUp() {
     super.setUp()
-    let memory = MemoryStorage<Bool>(config: MemoryConfig())
-    let disk = try! DiskStorage<Bool>(config: DiskConfig(name: "PrimitiveDisk"), transformer: TransformerFactory.forCodable(ofType: Bool.self))
-    storage = HybridStorage<Bool>(memoryStorage: memory, diskStorage: disk)
+    let memory = MemoryStorage<String, Bool>(config: MemoryConfig())
+    let disk = try! DiskStorage<String, Bool>(config: DiskConfig(name: "PrimitiveDisk"), transformer: TransformerFactory.forCodable(ofType: Bool.self))
+    storage = HybridStorage<String, Bool>(memoryStorage: memory, diskStorage: disk)
   }
 
   override func tearDown() {

--- a/Tests/iOS/Tests/Storage/StorageTests.swift
+++ b/Tests/iOS/Tests/Storage/StorageTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import Cache
 
 final class StorageTests: XCTestCase {
-  private var storage: Storage<User>!
+  private var storage: Storage<String, User>!
   let user = User(firstName: "John", lastName: "Snow")
 
   override func setUp() {
     super.setUp()
 
-    storage = try! Storage<User>(
+    storage = try! Storage<String, User>(
       diskConfig: DiskConfig(name: "Thor"),
       memoryConfig: MemoryConfig(),
       transformer: TransformerFactory.forCodable(ofType: User.self)
@@ -100,7 +100,7 @@ final class StorageTests: XCTestCase {
   // MARK: - Storage observers
 
   func testAddStorageObserver() throws {
-    var changes = [StorageChange]()
+    var changes = [StorageChange<String>]()
     var observer: ObserverMock? = ObserverMock()
 
     storage.addStorageObserver(observer!) { _, _, change in
@@ -115,7 +115,7 @@ final class StorageTests: XCTestCase {
     observer = nil
     try storage.setObject(user, forKey: "user1")
 
-    let expectedChanges: [StorageChange] = [
+    let expectedChanges: [StorageChange<String>] = [
       .add(key: "user1"),
       .add(key: "user2"),
       .remove(key: "user1"),
@@ -127,8 +127,8 @@ final class StorageTests: XCTestCase {
   }
 
   func testRemoveAllStorageObservers() throws {
-    var changes1 = [StorageChange]()
-    var changes2 = [StorageChange]()
+    var changes1 = [StorageChange<String>]()
+    var changes2 = [StorageChange<String>]()
 
     storage.addStorageObserver(self) { _, _, change in
       changes1.append(change)

--- a/Tests/iOS/Tests/Storage/SyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/SyncStorageTests.swift
@@ -3,14 +3,14 @@ import Dispatch
 @testable import Cache
 
 final class SyncStorageTests: XCTestCase {
-  private var storage: SyncStorage<User>!
+  private var storage: SyncStorage<String, User>!
   let user = User(firstName: "John", lastName: "Snow")
 
   override func setUp() {
     super.setUp()
 
-    let memory = MemoryStorage<User>(config: MemoryConfig())
-    let disk = try! DiskStorage<User>(config: DiskConfig(name: "HybridDisk"), transformer: TransformerFactory.forCodable(ofType: User.self))
+    let memory = MemoryStorage<String, User>(config: MemoryConfig())
+    let disk = try! DiskStorage<String, User>(config: DiskConfig(name: "HybridDisk"), transformer: TransformerFactory.forCodable(ofType: User.self))
 
     let hybridStorage = HybridStorage(memoryStorage: memory, diskStorage: disk)
     storage = SyncStorage(storage: hybridStorage, serialQueue: DispatchQueue(label: "Sync"))


### PR DESCRIPTION
This PR introduces an additional generic parameter Key to all the storage implementations.
This enables developers to use any Hashable type as keys...

For a better look at how we can do this, take a look at `Hasher+constantAccrossExecutions`

Have not gotten around to updating the Changelog or the Readme yet