### PR TITLE
Disable parallel test execution

### DIFF
--- a/Cache.xcodeproj/xcshareddata/xcschemes/Cache-iOS.xcscheme
+++ b/Cache.xcodeproj/xcshareddata/xcschemes/Cache-iOS.xcscheme
@@ -39,7 +39,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"


### PR DESCRIPTION
Since tests interact with local storage, they should be executed in serial order. Otherwise, they intervene with each other.
Resolves #274 