### PR TITLE
DiskStorage file URL handling improvements

### DIFF
--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -64,7 +64,7 @@ extension DiskStorage: StorageAware {
 
   public func entry(forKey key: Key) throws -> Entry<Value> {
     let filePath = makeFilePath(for: key)
-    let data = try Data(contentsOf: URL(fileURLWithPath: filePath))
+    let data = try Data(contentsOf: URL(fileURLWithPath: filePath, isDirectory: false))
     let attributes = try fileManager.attributesOfItem(atPath: filePath)
     let object = try transformer.fromData(data)
 
@@ -99,7 +99,7 @@ extension DiskStorage: StorageAware {
   }
 
   public func removeExpiredObjects() throws {
-    let storageURL = URL(fileURLWithPath: path)
+    let storageURL = URL(fileURLWithPath: path, isDirectory: true)
     let resourceKeys: [URLResourceKey] = [
       .isDirectoryKey,
       .contentModificationDateKey,
@@ -167,7 +167,7 @@ extension DiskStorage {
    */
   func makeFileName(for key: Key) -> String {
     if let key = key as? String {
-        let fileExtension = URL(fileURLWithPath: key).pathExtension
+        let fileExtension = (key as NSString).pathExtension
         let fileName = MD5(key)
 
         switch fileExtension.isEmpty {


### PR DESCRIPTION
This PR has a couple performance-related tweaks to how DiskStorage handles URLs.

The most significant is in the `DiskStorage.makeFileName(for:)` method. Currently, it uses the `URL(fileURLWithPath:)` initializer to extract the path extension (if any) from string keys. Per the [`NSURL` docs](https://developer.apple.com/documentation/foundation/nsurl/1410301-init), this does filesystem I/O for things like expanding relative paths and checking if the provided path is a directory on disk, and this is confirmed by multiple syscalls appearing up in a profile (below). Since this method doesn't actually care about what files exist on disk, we can cast the key to an `NSString` and use it's [`pathExtension`](https://developer.apple.com/documentation/foundation/nsstring/1407801-pathextension) property which merely _interprets_ the string as a path, rather than interacting with the filesystem.

![image](https://user-images.githubusercontent.com/7091588/104855470-f7e49680-58da-11eb-8cf7-6e3ac6ef1eb0.png)

Similarly, in the `entry(forKey:)` method, we know that the file path is not going to be a directory so we can use the `URL(fileURLWithPath:isDirectory:)` initializer to specify that it's not, avoiding the unnecessary disk I/O that happens if the path does not end with a slash. Again from the `NSURL` docs:

> This method assumes that path is a directory if it ends with a slash. If path does not end with a slash, the method examines the file system to determine if path is a file or a directory. If path exists in the file system and is a directory, the method appends a trailing slash. If path does not exist in the file system, the method assumes that it represents a file and does not append a trailing slash.

And, for completeness' sake, we can do the same in `removeExpiredObjects` because we know the `DiskStorage`'s path is always going to be a directory.