### PR TITLE
Use the same underlying DispatchQueue for sync/async access in Storage

### DIFF
--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -25,17 +25,13 @@ public final class Storage<Key: Hashable, Value> {
   /// Initialise with sync and async storages
   ///
   /// - Parameter syncStorage: Synchronous storage
-  /// - Paraeter: asyncStorage: Asynchronous storage
+  /// - Parameter asyncStorage: Asynchronous storage
   public init(hybridStorage: HybridStorage<Key, Value>) {
     self.hybridStorage = hybridStorage
-    self.syncStorage = SyncStorage(
-      storage: hybridStorage,
-      serialQueue: DispatchQueue(label: "Cache.SyncStorage.SerialQueue")
-    )
-    self.asyncStorage = AsyncStorage(
-      storage: hybridStorage,
-      serialQueue: DispatchQueue(label: "Cache.AsyncStorage.SerialQueue")
-    )
+
+    let queue = DispatchQueue(label: "Cache.Storage.SerialQueue")
+    self.syncStorage = SyncStorage(storage: hybridStorage, serialQueue: queue)
+    self.asyncStorage = AsyncStorage(storage: hybridStorage, serialQueue: queue)
   }
 
   /// Used for async operations


### PR DESCRIPTION
While using this library in one of the projects I've been working on recently I came across some crashes due to race conditions and upon further inspection I noticed that `Storage` uses different queues for accessing shared state - thus causing race conditions. 

Since the queues are used to protect shared state it makes sense to me to unify them so that all access happens on the same queue to ensure thread-safety.

Let me know what you think, happy for any feedback 🙂 👍🏻 