### PR TITLE
Add FOSS Compliance to SipHash

### DIFF
--- a/Source/Shared/Extensions/Hasher+constantAccrossExecutions.swift
+++ b/Source/Shared/Extensions/Hasher+constantAccrossExecutions.swift
@@ -1,3 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+/// This file implements SipHash-2-4 and SipHash-1-3
+/// (https://131002.net/siphash/).
+///
+/// This file is based on the reference C implementation, which was released
+/// to public domain by:
+///
+/// * Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+/// * Daniel J. Bernstein <djb@cr.yp.to>
+//===----------------------------------------------------------------------===//
 
 import Foundation
 


### PR DESCRIPTION
Hey there 👋 

In order to comply to FOSS, we need to add the original license to the file header of this file.

Cheers,
Roman