### PR TITLE
Fix SPM warning in Xcode 13b1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .target(
             name: "Cache",
-            path: "Source",
-            exclude: ["Library/ImageWrapper.swift"]),
+            path: "Source"
+        ),
         .testTarget(
             name: "CacheTests",
             dependencies: ["Cache"],


### PR DESCRIPTION
Also remove ImageWrapper as excluded in order to get tests going