### PR TITLE
Add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -13,7 +13,8 @@ let package = Package(
     targets: [
         .target(
             name: "Cache",
-            path: "Source"
+            path: "Source",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "CacheTests",

--- a/Source/PrivacyInfo.xcprivacy
+++ b/Source/PrivacyInfo.xcprivacy
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Source/PrivacyInfo.xcprivacy
+++ b/Source/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Source/PrivacyInfo.xcprivacy
+++ b/Source/PrivacyInfo.xcprivacy
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
Apple has declared that it will reject applications and SDKs without a privacy manifest starting in the spring of 2024.
SDKs that use `modificationDate` , `contentModificationDateKey` need a privacy manifest, so `PrivacyInfo.xcprivacy` has been added.

The following document was used as a reference for setting up the file.
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api