### PR TITLE
Fixed AsyncStorage `exists` not throwing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ let score = try? storage.object(forKey: "score")
 let favoriteCharacter = try? storage.object(forKey: "my favorite city")
 
 // Check if an object exists
-let hasFavoriteCharacter = try? storage.objectExists(forKey: "my favorite city")
+let hasFavoriteCharacter = storage.objectExists(forKey: "my favorite city")
 
 // Remove an object in storage
 try? storage.removeObject(forKey: "my favorite city")
@@ -263,8 +263,8 @@ storage.async.object(forKey: "my favorite city") { result in
   }
 }
 
-storage.async.objectExists(forKey: "my favorite city") { result in
-  if case .success(let exists) = result, exists {
+storage.async.objectExists(forKey: "my favorite city") { exists in
+  if exists {
     print("I have a favorite city")
   }
 }
@@ -305,12 +305,10 @@ do {
   print(error)
 }
 
-do {
-  let exists = try await storage.async.objectExists(forKey: "my favorite city")
-  if exists {
-    print("I have a favorite city")
-  }
-} catch {}
+let exists = await storage.async.objectExists(forKey: "my favorite city")
+if exists {
+  print("I have a favorite city")
+}
 
 do {
   try await storage.async.remoeAll()

--- a/Source/Shared/Storage/AsyncStorage.swift
+++ b/Source/Shared/Storage/AsyncStorage.swift
@@ -109,21 +109,27 @@ extension AsyncStorage {
   @available(*, deprecated, renamed: "objectExists(forKey:completion:)")
   public func existsObject(
     forKey key: Key,
-    completion: @escaping (Result<Bool, Error>) -> Void) {
+    completion: @escaping (Bool) -> Void) {
     object(forKey: key, completion: { (result: Result<Value, Error>) in
-      completion(result.map({ _ in
-        return true
-      }))
+      switch result {
+      case .success:
+        completion(true)
+      case .failure:
+        completion(false)
+      }
     })
   }
 
   public func objectExists(
     forKey key: Key,
-    completion: @escaping (Result<Bool, Error>) -> Void) {
+    completion: @escaping (Bool) -> Void) {
       object(forKey: key, completion: { (result: Result<Value, Error>) in
-        completion(result.map({ _ in
-          return true
-        }))
+        switch result {
+        case .success:
+          completion(true)
+        case .failure:
+          completion(false)
+        }
       })
     }
 }
@@ -192,10 +198,10 @@ public extension AsyncStorage {
     }
   }
 
-  func objectExists(forKey key: Key) async throws -> Bool {
-    try await withCheckedThrowingContinuation { continuation in
+  func objectExists(forKey key: Key) async -> Bool {
+    await withCheckedContinuation { continuation in
       objectExists(forKey: key) {
-        continuation.resume(with: $0)
+        continuation.resume(returning: $0)
       }
     }
   }

--- a/Source/Shared/Storage/StorageAware.swift
+++ b/Source/Shared/Storage/StorageAware.swift
@@ -48,7 +48,7 @@ public protocol StorageAware {
    - Parameter key: Unique key to identify the object.
    */
   @available(*, deprecated, renamed: "objectExists(forKey:)")
-  func existsObject(forKey key: Key) throws -> Bool
+  func existsObject(forKey key: Key) -> Bool
 
   /**
    Check if an object exist by the given key.
@@ -83,7 +83,7 @@ public extension StorageAware {
     return try entry(forKey: key).object
   }
 
-  func existsObject(forKey key: Key) throws -> Bool {
+  func existsObject(forKey key: Key) -> Bool {
     do {
       let _: Value = try object(forKey: key)
       return true

--- a/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
+++ b/Tests/iOS/Tests/Storage/AsyncStorageTests.swift
@@ -58,11 +58,10 @@ final class AsyncStorageTests: XCTestCase {
     }
 
     then("all are removed") {
-      intStorage.objectExists(forKey: "key-99", completion: { result in
-        switch result {
-        case .success:
+      intStorage.objectExists(forKey: "key-99", completion: { exists in
+        if exists {
           XCTFail()
-        default:
+        } else {
           expectation.fulfill()
         }
       })
@@ -85,10 +84,8 @@ final class AsyncStorageTests: XCTestCase {
     }
 
     await then("all are removed") {
-      do {
-        _ = try await intStorage.objectExists(forKey: "key-99")
-        XCTFail()
-      } catch {}
+      let exists = await intStorage.objectExists(forKey: "key-99")
+      XCTAssertFalse(exists)
     }
   }
 }


### PR DESCRIPTION
Current `existsObject()` returns true or throw error, not returning false.
As per [StorageAware](https://github.com/hyperoslo/Cache/blob/fd97438a85d44aa4f7186145cdba90e3c36f1c94/Source/Shared/Storage/StorageAware.swift#L95), `existsObject()` should not throw an error.
Fix `existsObject()` to return false instead of error.