### PR TITLE
Allos custom FileManager to be passed in for DiskStorage.

### DIFF
--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -44,9 +44,6 @@ final public class DiskStorage<Key: Hashable, Value> {
         FileAttributeKey.protectionKey: protectionType
       ])
     }
-      
-//      defaultFileAttributes = fileAttributes
-
   }
 
   public required init(config: DiskConfig, fileManager: FileManager = FileManager.default, path: String, transformer: Transformer<Value>) {

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -17,11 +17,10 @@ final public class DiskStorage<Key: Hashable, Value> {
 
   private let transformer: Transformer<Value>
   private let hasher = Hasher.constantAccrossExecutions()
-    private var defaultFileAttributes: [FileAttributeKey : Any]?
+//    private var defaultFileAttributes: [FileAttributeKey : Any]?
 
   // MARK: - Initialization
-  public convenience init(config: DiskConfig, fileManager: FileManager = FileManager.default, transformer: Transformer<Value>,
-                          fileAttributes: [FileAttributeKey : Any] = [:]) throws {
+  public convenience init(config: DiskConfig, fileManager: FileManager = FileManager.default, transformer: Transformer<Value>) throws {
     let url: URL
     if let directory = config.directory {
       url = directory
@@ -47,7 +46,7 @@ final public class DiskStorage<Key: Hashable, Value> {
       ])
     }
       
-      defaultFileAttributes = fileAttributes
+//      defaultFileAttributes = fileAttributes
 
   }
 
@@ -85,11 +84,11 @@ extension DiskStorage: StorageAware {
     let expiry = expiry ?? config.expiry
     let data = try transformer.toData(object)
     let filePath = makeFilePath(for: key)
-      var attributes = defaultFileAttributes!
-      attributes[.modificationDate] = expiry.date
-      
-    _ = fileManager.createFile(atPath: filePath, contents: data, attributes: attributes)
-//    try fileManager.setAttributes([.modificationDate: expiry.date], ofItemAtPath: filePath)
+//      var attributes = defaultFileAttributes!
+//      attributes[.modificationDate] = expiry.date
+//      
+    _ = fileManager.createFile(atPath: filePath, contents: data, attributes: nil)
+    try fileManager.setAttributes([.modificationDate: expiry.date], ofItemAtPath: filePath)
   }
 
   public func removeObject(forKey key: Key) throws {

--- a/Source/Shared/Storage/DiskStorage.swift
+++ b/Source/Shared/Storage/DiskStorage.swift
@@ -17,7 +17,6 @@ final public class DiskStorage<Key: Hashable, Value> {
 
   private let transformer: Transformer<Value>
   private let hasher = Hasher.constantAccrossExecutions()
-//    private var defaultFileAttributes: [FileAttributeKey : Any]?
 
   // MARK: - Initialization
   public convenience init(config: DiskConfig, fileManager: FileManager = FileManager.default, transformer: Transformer<Value>) throws {
@@ -84,9 +83,6 @@ extension DiskStorage: StorageAware {
     let expiry = expiry ?? config.expiry
     let data = try transformer.toData(object)
     let filePath = makeFilePath(for: key)
-//      var attributes = defaultFileAttributes!
-//      attributes[.modificationDate] = expiry.date
-//      
     _ = fileManager.createFile(atPath: filePath, contents: data, attributes: nil)
     try fileManager.setAttributes([.modificationDate: expiry.date], ofItemAtPath: filePath)
   }

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -15,8 +15,8 @@ public final class Storage<Key: Hashable, Value> {
   ///   - diskConfig: Configuration for disk storage
   ///   - memoryConfig: Optional. Pass config if you want memory cache
   /// - Throws: Throw StorageError if any.
-  public convenience init(diskConfig: DiskConfig, memoryConfig: MemoryConfig, transformer: Transformer<Value>) throws {
-    let disk = try DiskStorage<Key, Value>(config: diskConfig, transformer: transformer)
+    public convenience init(diskConfig: DiskConfig, memoryConfig: MemoryConfig, fileManager: FileManager, transformer: Transformer<Value>) throws {
+    let disk = try DiskStorage<Key, Value>(config: diskConfig, fileManager: fileManager, transformer: transformer)
     let memory = MemoryStorage<Key, Value>(config: memoryConfig)
     let hybridStorage = HybridStorage(memoryStorage: memory, diskStorage: disk)
     self.init(hybridStorage: hybridStorage)


### PR DESCRIPTION
On Apple Silicon M1 systems the umask value is not being used when the cached files are created. Allowing a default FileManager with explicitly sets POSIX permissions in the attributes fixes this issue.