### PR TITLE
Fix unit test

### DIFF
--- a/Tests/iOS/Tests/Storage/StorageTests.swift
+++ b/Tests/iOS/Tests/Storage/StorageTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Cache
 
 final class StorageTests: XCTestCase {
+  private let fileManager = FileManager()
   private var storage: Storage<String, User>!
   let user = User(firstName: "John", lastName: "Snow")
 
@@ -11,6 +12,7 @@ final class StorageTests: XCTestCase {
     storage = try! Storage<String, User>(
       diskConfig: DiskConfig(name: "Thor"),
       memoryConfig: MemoryConfig(),
+      fileManager: fileManager,
       transformer: TransformerFactory.forCodable(ofType: User.self)
     )
   }


### PR DESCRIPTION
The commit db45d9f4b1a7b80df1b96adb168861126b7983d0 added a FileManager argument to the `Storage` initializer, but it was not reflected in the unit tests, so I have fixed that.