### PR TITLE
Add support for contentAccessDate-based expiry and cleanup using custom expiry period

### DIFF
--- a/Source/Shared/Storage/HybridStorage.swift
+++ b/Source/Shared/Storage/HybridStorage.swift
@@ -88,6 +88,13 @@ extension HybridStorage: StorageAware {
 
     notifyStorageObservers(about: .removeExpired)
   }
+
+  public func removeExpiredObjects(expiryPeriod: TimeInterval? = nil) throws {
+    memoryStorage.removeExpiredObjects()
+    try diskStorage.removeExpiredObjects(expiryPeriod: expiryPeriod)
+
+    notifyStorageObservers(about: .removeExpired)
+  }
 }
 
 public extension HybridStorage {

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -74,6 +74,10 @@ extension Storage: StorageAware {
   public func removeExpiredObjects() throws {
     try self.syncStorage.removeExpiredObjects()
   }
+
+  public func removeExpiredObjects(expiryPeriod: TimeInterval? = nil) throws {
+    try self.syncStorage.removeExpiredObjects()
+  }
 }
 
 public extension Storage {

--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -76,7 +76,7 @@ extension Storage: StorageAware {
   }
 
   public func removeExpiredObjects(expiryPeriod: TimeInterval? = nil) throws {
-    try self.syncStorage.removeExpiredObjects()
+    try self.syncStorage.removeExpiredObjects(expiryPeriod: expiryPeriod)
   }
 }
 

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -62,6 +62,12 @@ extension SyncStorage: StorageAware {
     }
   }
 
+  public func removeExpiredObjects(expiryPeriod: TimeInterval? = nil) throws {
+    try serialQueue.sync {
+      try innerStorage.removeExpiredObjects()
+    }
+  }
+
   public func removeInMemoryObject(forKey key: Key) throws {
     try serialQueue.sync {
     try self.innerStorage.removeInMemoryObject(forKey: key)

--- a/Source/Shared/Storage/SyncStorage.swift
+++ b/Source/Shared/Storage/SyncStorage.swift
@@ -64,7 +64,7 @@ extension SyncStorage: StorageAware {
 
   public func removeExpiredObjects(expiryPeriod: TimeInterval? = nil) throws {
     try serialQueue.sync {
-      try innerStorage.removeExpiredObjects()
+      try innerStorage.removeExpiredObjects(expiryPeriod: expiryPeriod)
     }
   }
 


### PR DESCRIPTION
This PR adds support for cache cleanup based on a custom expiry period using the file’s `contentAccessDate`.

- Added a new `removeExpiredObjects(expiryPeriod:)` function.

- This compares the current time with each file’s contentAccessDate (if available) or modificationDate as a fallback.

- If the file hasn’t been accessed within the specified `expiryPeriod`, it is removed from the cache.