### PR TITLE
Default FileManager

### DIFF
--- a/Source/Shared/Storage/Storage.swift
+++ b/Source/Shared/Storage/Storage.swift
@@ -15,7 +15,7 @@ public final class Storage<Key: Hashable, Value> {
   ///   - diskConfig: Configuration for disk storage
   ///   - memoryConfig: Optional. Pass config if you want memory cache
   /// - Throws: Throw StorageError if any.
-    public convenience init(diskConfig: DiskConfig, memoryConfig: MemoryConfig, fileManager: FileManager, transformer: Transformer<Value>) throws {
+    public convenience init(diskConfig: DiskConfig, memoryConfig: MemoryConfig, fileManager: FileManager = FileManager.default, transformer: Transformer<Value>) throws {
     let disk = try DiskStorage<Key, Value>(config: diskConfig, fileManager: fileManager, transformer: transformer)
     let memory = MemoryStorage<Key, Value>(config: memoryConfig)
     let hybridStorage = HybridStorage(memoryStorage: memory, diskStorage: disk)


### PR DESCRIPTION
#329 allowed specifying a `FileManager` in a `Storage` struct. This change introduced a required parameter, causing compiler errors for anyone upgrading. It could have been an optional parameter and defaulted. This PR aims to bring `7.x` releases back into compatibility with semver since a major version bump did not happen, but a breaking change was made.